### PR TITLE
Minimise impact of historical clients on live stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.20</nukleus.plugin.version>
     <nukleus.version>0.12</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.7</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.32</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.20</nukleus.plugin.version>
     <nukleus.version>0.13</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.9</nukleus.kafka.spec.version>
     <reaktor.version>0.33</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/function/PartitionResponseConsumer.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/function/PartitionResponseConsumer.java
@@ -20,5 +20,5 @@ import org.agrona.DirectBuffer;
 @FunctionalInterface
 public interface PartitionResponseConsumer
 {
-    void accept(DirectBuffer buffer, int index, int length, PartitionProgressHandler progressHandler);
+    void accept(DirectBuffer buffer, int index, int length, long requestedOffset, PartitionProgressHandler progressHandler);
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -90,7 +90,7 @@ public final class ClientStreamFactory implements StreamFactory
     final BufferPool bufferPool;
     private final MutableDirectBuffer writeBuffer;
 
-    final Long2ObjectHashMap<NetworkConnectionPool.NetworkConnection> correlations;
+    final Long2ObjectHashMap<NetworkConnectionPool.AbstractNetworkConnection> correlations;
     private final Map<String, Long2ObjectHashMap<NetworkConnectionPool>> connectionPools;
 
     public ClientStreamFactory(
@@ -100,7 +100,7 @@ public final class ClientStreamFactory implements StreamFactory
         BufferPool bufferPool,
         LongSupplier supplyStreamId,
         LongSupplier supplyCorrelationId,
-        Long2ObjectHashMap<NetworkConnectionPool.NetworkConnection> correlations)
+        Long2ObjectHashMap<NetworkConnectionPool.AbstractNetworkConnection> correlations)
     {
         this.router = requireNonNull(router);
         this.writeBuffer = requireNonNull(writeBuffer);
@@ -189,7 +189,7 @@ public final class ClientStreamFactory implements StreamFactory
         MessageConsumer handleStream = null;
         if (networkReplyRef == 0L)
         {
-            final NetworkConnectionPool.NetworkConnection connection = correlations.remove(networkReplyCorrelationId);
+            final NetworkConnectionPool.AbstractNetworkConnection connection = correlations.remove(networkReplyCorrelationId);
             if (connection != null)
             {
                 handleStream = connection.onCorrelated(networkReplyThrottle, networkReplyId);

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -539,6 +539,7 @@ public final class ClientStreamFactory implements StreamFactory
             DirectBuffer buffer,
             int offset,
             int length,
+            long requestedOffset,
             PartitionProgressHandler progressHandler)
         {
             final int maxLimit = offset + length;
@@ -554,7 +555,8 @@ public final class ClientStreamFactory implements StreamFactory
             long nextFetchAt = firstFetchAt;
 
             // TODO: determine appropriate reaction to different non-zero error codes
-            if (partition.errorCode() == 0 && networkOffset < maxLimit - BitUtil.SIZE_OF_INT)
+            if (partition.errorCode() == 0 && networkOffset < maxLimit - BitUtil.SIZE_OF_INT
+                    && requestedOffset <= firstFetchAt) // avoid out of order delivery
             {
                 final RecordSetFW recordSet = recordSetRO.wrap(buffer, networkOffset, maxLimit);
                 networkOffset = recordSet.limit();

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactoryBuilder.java
@@ -29,7 +29,7 @@ import org.reaktivity.nukleus.stream.StreamFactoryBuilder;
 public final class ClientStreamFactoryBuilder implements StreamFactoryBuilder
 {
     private final KafkaConfiguration config;
-    private final Long2ObjectHashMap<NetworkConnectionPool.NetworkConnection> correlations;
+    private final Long2ObjectHashMap<NetworkConnectionPool.AbstractNetworkConnection> correlations;
 
     private RouteManager router;
     private MutableDirectBuffer writeBuffer;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -236,7 +236,7 @@ final class NetworkConnectionPool
         // TODO: If the topic now has no partitions, remove from topicsByName and topicMetadataByName
     }
 
-    abstract class NetworkConnection
+    abstract class AbstractNetworkConnection
     {
         final MessageConsumer networkTarget;
 
@@ -259,7 +259,7 @@ final class NetworkConnectionPool
         int nextRequestId;
         int nextResponseId;
 
-        private NetworkConnection()
+        private AbstractNetworkConnection()
         {
             this.networkTarget = NetworkConnectionPool.this.clientStreamFactory.router.supplyTarget(networkName);
         }
@@ -300,7 +300,7 @@ final class NetworkConnectionPool
                 final long newNetworkId = NetworkConnectionPool.this.clientStreamFactory.supplyStreamId.getAsLong();
                 final long newCorrelationId = NetworkConnectionPool.this.clientStreamFactory.supplyCorrelationId.getAsLong();
 
-                NetworkConnectionPool.this.clientStreamFactory.correlations.put(newCorrelationId, NetworkConnection.this);
+                NetworkConnectionPool.this.clientStreamFactory.correlations.put(newCorrelationId, AbstractNetworkConnection.this);
 
                 NetworkConnectionPool.this.clientStreamFactory
                     .doBegin(networkTarget, newNetworkId, networkRef, newCorrelationId, extensionVisitor);
@@ -556,7 +556,7 @@ final class NetworkConnectionPool
         }
     }
 
-    final class FetchConnection extends NetworkConnection
+    final class FetchConnection extends AbstractNetworkConnection
     {
         private final int brokerId;
         private final String host;
@@ -745,7 +745,7 @@ final class NetworkConnectionPool
         }
     }
 
-    private final class MetadataConnection extends NetworkConnection
+    private final class MetadataConnection extends AbstractNetworkConnection
     {
         TopicMetadata pendingTopicMetadata;
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
@@ -87,8 +87,8 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${scripts}/fanout.with.historical.message/client",
-        "${scripts}/fanout.with.historical.message/server"})
+        "${client}/fanout.with.historical.message/client",
+        "${server}/fanout.with.historical.message/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldFanoutUsingHistoricalConnection() throws Exception
     {
@@ -98,8 +98,8 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${scripts}/fanout.with.historical.messages/client",
-        "${scripts}/fanout.with.historical.messages/server"})
+        "${client}/fanout.with.historical.messages/client",
+        "${server}/fanout.with.historical.messages/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldFanoutDiscardingHistoricalMessageToJoinLiveStream() throws Exception
     {
@@ -109,8 +109,8 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${scripts}/fanout.with.slow.consumer/client",
-        "${scripts}/fanout.with.slow.consumer/server"})
+        "${client}/fanout.with.slow.consumer/client",
+        "${server}/fanout.with.slow.consumer/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldFanoutWithSlowConsumer() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
@@ -84,6 +84,7 @@ public class FetchIT
         k3po.finish();
     }
 
+    @Ignore // TODO:
     @Test
     @Specification({
         "${route}/client/controller",
@@ -95,6 +96,7 @@ public class FetchIT
         k3po.finish();
     }
 
+    @Ignore // TODO:
     @Test
     @Specification({
         "${route}/client/controller",
@@ -106,6 +108,7 @@ public class FetchIT
         k3po.finish();
     }
 
+    @Ignore // TODO:
     @Test
     @Specification({
         "${route}/client/controller",
@@ -135,6 +138,17 @@ public class FetchIT
         "${server}/zero.offset.message/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveMessageAtZeroOffset() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/zero.offset.message/client",
+        "${server}/zero.offset.message.single.partition.multiple.nodes/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldNotFetchFromNodeWithNoPartitions() throws Exception
     {
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
@@ -87,6 +87,39 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${scripts}/fanout.with.historical.message/client",
+        "${scripts}/fanout.with.historical.message/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldFanoutUsingHistoricalConnection() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${scripts}/fanout.with.historical.messages/client",
+        "${scripts}/fanout.with.historical.messages/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldFanoutDiscardingHistoricalMessageToJoinLiveStream() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${scripts}/fanout.with.slow.consumer/client",
+        "${scripts}/fanout.with.slow.consumer/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldFanoutWithSlowConsumer() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/zero.offset/client",
         "${server}/zero.offset/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
@@ -84,7 +84,6 @@ public class FetchIT
         k3po.finish();
     }
 
-    @Ignore // TODO:
     @Test
     @Specification({
         "${route}/client/controller",
@@ -96,7 +95,6 @@ public class FetchIT
         k3po.finish();
     }
 
-    @Ignore // TODO:
     @Test
     @Specification({
         "${route}/client/controller",
@@ -108,7 +106,6 @@ public class FetchIT
         k3po.finish();
     }
 
-    @Ignore // TODO:
     @Test
     @Specification({
         "${route}/client/controller",
@@ -274,6 +271,28 @@ public class FetchIT
         k3po.notifyBarrier("SERVER_DELIVER_RESPONSE_ONE");
         k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
         k3po.notifyBarrier("SERVER_DELIVER_RESPONSE_TWO");
+        k3po.notifyBarrier("SERVER_DELIVER_HISTORICAL_RESPONSE");
+        k3po.awaitBarrier("CLIENT_ONE_RECEIVED_THIRD_MESSAGE");
+        k3po.notifyBarrier("SERVER_DELIVER_RESPONSE_THREE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/distinct.offset.messagesets.fanout/client",
+        "${server}/distinct.offset.messagesets.fanout/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldFanoutMessageSetsAtDistinctOffsetsWithoutDeliveringLiveMessageOutOfOrder() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("CLIENT_ONE_CONNECTED");
+        k3po.notifyBarrier("SERVER_DELIVER_RESPONSE_ONE");
+        k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
+        k3po.notifyBarrier("SERVER_DELIVER_RESPONSE_TWO");
+        k3po.notifyBarrier("SERVER_DELIVER_RESPONSE_THREE");
+        k3po.awaitBarrier("CLIENT_ONE_RECEIVED_THIRD_MESSAGE");
+        k3po.notifyBarrier("SERVER_DELIVER_HISTORICAL_RESPONSE");
         k3po.finish();
     }
 }


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/4.

This is the fix for issue #4. I introduces HistoricalFetchConnections, one per broker. 

HistoricalFetchConnection does fetches for all topic partitions where there is divergence in the requested offsets, using the lowest requested offset. A BitSet is used on NetworkTopic to mark partitions with divergence so a cheap decision can be made about whether or not a historical fetch is needed.

FetchConnection now does only live stream fetches, that is, fetching from the highest requested offset. In order to avoid accidentally delivering a live message to a historical consumer, resulting in an out of order message delivery, I had to add a fourth parameter to PartitionResponseConsumer giving the requested fetch offset.