### PR TITLE
Fixed doDetach in NetworkConnectionPool to remove the NetworkTopic fr…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.22</nukleus.plugin.version>
     <nukleus.version>0.13</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.12</nukleus.kafka.spec.version>
     <reaktor.version>0.33</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.22</nukleus.plugin.version>
     <nukleus.version>0.13</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.11</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.33</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -323,7 +323,6 @@ final class NetworkConnectionPool
         {
             detacher.accept(fetchOffsets);
         }
-        // TODO: If the topic now has no partitions, remove from topicsByName and topicMetadataByName
     }
 
     abstract class AbstractNetworkConnection
@@ -1142,6 +1141,12 @@ final class NetworkConnectionPool
             {
                 partitionId++;
                 doDetach(partitionId, iterator.nextValue(), consumeRecords, supplyWindow);
+            }
+            if (partitions.isEmpty())
+            {
+                topicsByName.remove(topicName);
+                topicMetadataByName.remove(topicName);
+
             }
         }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
@@ -362,6 +362,22 @@ public class FetchIT
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveMessageAtZeroOffset() throws Exception
     {
+        k3po.start();
+        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/zero.offset.and.reset/client",
+        "${server}/zero.offset.message/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldHandleFetchResponseAfterUnsubscribe() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("SUBSCRIBED");
+        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
         k3po.finish();
     }
 


### PR DESCRIPTION
…om topicsByName and topicMetadataByName to free up memory and avoid NPE when processing a subsequent fetch response.

Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/9.