### PR TITLE
Fixed handling of unknown topic error to avoid IndexOutOfBoundsException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.24</nukleus.plugin.version>
     <nukleus.version>0.15</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.14</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.35</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1056,6 +1056,10 @@ final class NetworkConnectionPool
             {
                 pendingTopicMetadata.setErrorCode(errorCode);
                 pendingTopicMetadata.flush();
+                if (errorCode != NONE)
+                {
+                    topicMetadataByName.remove(pendingTopicMetadata.topicName);
+                }
             }
         }
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
@@ -38,7 +38,7 @@ public class FetchIT
             .addScriptRoot("metadata", "org/reaktivity/specification/kafka/metadata.v5")
             .addScriptRoot("client", "org/reaktivity/specification/nukleus/kafka/streams/fetch");
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(15, SECONDS));
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
 
     private final ReaktorRule reaktor = new ReaktorRule()
         .nukleus("kafka"::equals)
@@ -112,7 +112,7 @@ public class FetchIT
 
     @Test
     @Specification({
-        "${route}/client/controller",
+        "${routeAnyTopic}/client/controller",
         "${client}/unknown.topic.name/client",
         "${metadata}/one.topic.error.unknown.topic/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")


### PR DESCRIPTION
...that was caused by incorrectly attempting to redo the metadata query. 

NOTE: these changes are now included in https://github.com/reaktivity/nukleus-kafka.java/pull/20

#### Details
Fixed handleResponse in MetadataConnection to remove the entry from topicMetadataByName so we don't keep on trying to get the metadata for an unknown or otherwise errored topic.

#### Depends on
https://github.com/reaktivity/nukleus-kafka.spec/pull/11