### PR TITLE
Fixed handling of begin with fetch key and empty offsets array 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.18</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.38</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.19</nukleus.kafka.spec.version>
     <reaktor.version>0.38</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -254,6 +254,7 @@ final class NetworkConnectionPool
             break;
         case NONE:
             int partitionId = BufferUtil.partition(partitionHash, topicMetadata.partitionCount());
+            fetchOffsets.computeIfAbsent(0L, v -> 0L);
             if (partitionId != 0)
             {
                 long offset = fetchOffsets.remove(0L);

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchIT.java
@@ -225,6 +225,17 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/fetch.key.no.offsets.message/client",
+        "${server}/fetch.key.zero.offset.first.matches/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveMessageMatchingFetchKeyFirstWithZeroLengthOffsetsArray() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/fetch.key.zero.offset.message/client",
         "${server}/fetch.key.zero.offset.last.matches/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
@@ -416,6 +427,19 @@ public class FetchIT
         "${server}/zero.offset.message/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveMessageAtZeroOffset() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/no.offsets.message/client",
+        "${server}/zero.offset.message/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveMessageAtZeroOffsetWhenEmptyOffsetsArray() throws Exception
     {
         k3po.start();
         k3po.notifyBarrier("WRITE_FETCH_RESPONSE");


### PR DESCRIPTION
…so we do actually fetch messages in that case.

REQUIRES: https://github.com/reaktivity/nukleus-kafka.spec/pull/14