### PR TITLE
Limit maximum fetch bytes to avoid fetch response side from exceeding available slot capacity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.20</nukleus.kafka.spec.version>
     <reaktor.version>0.38</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.19</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.38</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchLimitsIT.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.streams;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.k3po.junit.annotation.ScriptProperty;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.reaktivity.reaktor.internal.ReaktorConfiguration;
+import org.reaktivity.reaktor.test.ReaktorRule;
+
+public class FetchLimitsIT
+{
+    private final K3poRule k3po = new K3poRule()
+            .addScriptRoot("route", "org/reaktivity/specification/nukleus/kafka/control/route.ext")
+            .addScriptRoot("routeAnyTopic", "org/reaktivity/specification/nukleus/kafka/control/route")
+            .addScriptRoot("server", "org/reaktivity/specification/kafka/fetch.v5")
+            .addScriptRoot("metadata", "org/reaktivity/specification/kafka/metadata.v5")
+            .addScriptRoot("client", "org/reaktivity/specification/nukleus/kafka/streams/fetch");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+
+    private final ReaktorRule reaktor = new ReaktorRule()
+        .nukleus("kafka"::equals)
+        .directory("target/nukleus-itests")
+        .commandBufferCapacity(1024)
+        .responseBufferCapacity(1024)
+        .counterValuesBufferCapacity(1024)
+        .clean()
+        .configure(ReaktorConfiguration.BUFFER_SLOT_CAPACITY_PROPERTY, 256);
+
+    @Rule
+    public final TestRule chain = outerRule(reaktor).around(k3po).around(timeout);
+
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/zero.offset.messages.multiple.partitions.max.bytes.256/client",
+        "${server}/zero.offset.messages.multiple.partitions.max.bytes.256/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveMessagesFromMultiplePartitionsWhenResponseSizeEqualsSlotSize() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/zero.offset/client",
+        "${server}/zero.offset.message.response.exceeds.requested.256.bytes/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldHandleFetchResponseExceedingRequestedMaxFetchBytes() throws Exception
+    {
+        expected.expect(IllegalStateException.class);
+        k3po.start();
+        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
+        k3po.finish();
+    }
+}


### PR DESCRIPTION
This resolves an issue where message flow would stop because we never receive a complete fetch response because the size exceeds the window we have given on the Kafka  connection.  This condition could arise most easily with consumers on more than one topic partition.

REQUIRES: https://github.com/reaktivity/nukleus-kafka.spec/pull/15https://github.com/reaktivity/nukleus-kafka.spec/pull/15