### PR TITLE
Fix npe on unsubscribe

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1374,8 +1374,8 @@ final class NetworkConnectionPool
             candidate.id = partitionId;
             candidate.offset = Long.MAX_VALUE;
             NetworkTopicPartition floor = partitions.floor(candidate);
-            assert floor.id == partitionId;
-            return floor.offset;
+            assert floor == null || floor.id == partitionId;
+            return floor != null ? floor.offset : 0L;
         }
 
         long getLowestOffset(
@@ -1384,8 +1384,8 @@ final class NetworkConnectionPool
             candidate.id = partitionId;
             candidate.offset = 0L;
             NetworkTopicPartition ceiling = partitions.ceiling(candidate);
-            assert ceiling.id == partitionId;
-            return ceiling.offset;
+            assert ceiling == null || ceiling.id == partitionId;
+            return ceiling != null ? ceiling.offset : Long.MAX_VALUE;
         }
 
         void onPartitionResponse(


### PR DESCRIPTION
Fixes the following NPE which can occur when the last client unsubscribes from a topic:
```
java.lang.NullPointerException
	at org.reaktivity.nukleus.kafka.internal.stream.NetworkConnectionPool$NetworkTopic.getHighestOffset(NetworkConnectionPool.java:1378)
	at org.reaktivity.nukleus.kafka.internal.stream.NetworkConnectionPool$LiveFetchConnection.getRequestedOffset(NetworkConnectionPool.java:917)
	at org.reaktivity.nukleus.kafka.internal.stream.NetworkConnectionPool$AbstractFetchConnection.handleResponse(NetworkConnectionPool.java:855)
	at org.reaktivity.nukleus.kafka.internal.stream.NetworkConnectionPool$AbstractNetworkConnection.handleData(NetworkConnectionPool.java:601)
	at org.reaktivity.nukleus.kafka.internal.stream.NetworkConnectionPool$AbstractNetworkConnection.afterBegin(NetworkConnectionPool.java:518)
	at org.reaktivity.nukleus.kafka.internal.stream.NetworkConnectionPool$AbstractNetworkConnection.handleStream(NetworkConnectionPool.java:488)
```