### PR TITLE
Fixed a bug in the logic to remove an entry from the correlations map…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.24</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.38</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.25</nukleus.kafka.spec.version>
     <reaktor.version>0.38</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -357,6 +357,7 @@ final class NetworkConnectionPool
         final MessageConsumer networkTarget;
 
         long networkId;
+        long networkCorrelationId;
 
         int networkRequestBudget;
         int networkRequestPadding;
@@ -404,7 +405,7 @@ final class NetworkConnectionPool
             });
         }
 
-        void doBeginIfNotConnected(Flyweight.Builder.Visitor extensionVisitor)
+        final void doBeginIfNotConnected(Flyweight.Builder.Visitor extensionVisitor)
         {
             if (networkId == 0L)
             {
@@ -423,6 +424,7 @@ final class NetworkConnectionPool
                         networkName, newNetworkId, this::handleThrottle);
 
                 this.networkId = newNetworkId;
+                this.networkCorrelationId = newCorrelationId;
             }
         }
 
@@ -475,7 +477,8 @@ final class NetworkConnectionPool
         private void handleReset(
             ResetFW reset)
         {
-            NetworkConnectionPool.this.clientStreamFactory.correlations.remove(networkId, AbstractNetworkConnection.this);
+            NetworkConnectionPool.this.clientStreamFactory.correlations.remove(
+                    networkCorrelationId, AbstractNetworkConnection.this);
             doReinitialize();
             doRequestIfNeeded();
         }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/MetadataIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/MetadataIT.java
@@ -64,6 +64,17 @@ public class MetadataIT
     @Specification({
         "${route}/client/controller",
         "${client}/zero.offset/client",
+        "${metadata}/broker.connection.reset.and.retry/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldRetryWhenBrokerNotAvailable() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/zero.offset/client",
         "${metadata}/one.topic.multiple.nodes/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldHandleMetadataResponseOneTopicOnMultipleNodes() throws Exception


### PR DESCRIPTION
… in NetworkConnectionPoolhandleReset.

Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/20