### PR TITLE
Added timestamps to kafka data extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-<nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.27</nukleus.kafka.spec.version>
     <reaktor.version>0.38</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <jmock.version>2.6.0</jmock.version>
 
     <k3po.version>3.0.0-alpha-88</k3po.version>
-    <k3po.nukleus.ext.version>0.18</k3po.nukleus.ext.version>
+    <k3po.nukleus.ext.version>0.19</k3po.nukleus.ext.version>
 
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.24</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.38</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+<nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.38</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/streams/FetchLimitsIT.java
@@ -16,6 +16,10 @@
 package org.reaktivity.nukleus.kafka.internal.streams;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.isA;
 import static org.junit.rules.RuleChain.outerRule;
 
 import org.junit.Rule;
@@ -75,7 +79,8 @@ public class FetchLimitsIT
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldHandleFetchResponseExceedingRequestedMaxFetchBytes() throws Exception
     {
-        expected.expect(IllegalStateException.class);
+        expected.expect(anyOf(isA(IllegalStateException.class),
+                hasProperty("failures", hasItem(isA(IllegalStateException.class)))));
         k3po.start();
         k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
         k3po.finish();


### PR DESCRIPTION
Requires further spec changes: https://github.com/reaktivity/nukleus-kafka.spec/pull/22

@jfallows Ready for re-review. Changes since you reviewed are 
- pom.xml to pick up spec changes
- FetchLimitsIT: fix check for expected exception to avoid sporadic fails
