### PR TITLE
Message dispatchers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <checkstyle.config.location>src/conf/checkstyle/configuration.xml</checkstyle.config.location>
     <checkstyle.suppressions.location>src/conf/checkstyle/suppressions.xml</checkstyle.suppressions.location>
-    <jacoco.coverage.ratio>0.46</jacoco.coverage.ratio>
-    <jacoco.missed.count>77</jacoco.missed.count>
+    <jacoco.coverage.ratio>0.49</jacoco.coverage.ratio>
+    <jacoco.missed.count>74</jacoco.missed.count>
 
     <junit.version>4.12</junit.version>
     <jmh.version>1.17.4</jmh.version>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/function/IntBooleanConsumer.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/function/IntBooleanConsumer.java
@@ -13,27 +13,10 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package org.reaktivity.nukleus.kafka.internal.stream;
+package org.reaktivity.nukleus.kafka.internal.function;
 
-import java.util.function.Function;
-
-import org.agrona.DirectBuffer;
-
-public interface MessageDispatcher
+@FunctionalInterface
+public interface IntBooleanConsumer
 {
-
-    int dispatch(
-             int partition,
-             long requestOffset,
-             long messageOffset,
-             DirectBuffer key,
-             Function<DirectBuffer, DirectBuffer> supplyHeader,
-             long timestamp,
-             DirectBuffer value);
-
-    void flush(
-            int partition,
-            long requestOffset,
-            long lastOffset);
-
+    void accept(int intValue, boolean booleanValue);
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcher.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import org.agrona.DirectBuffer;
+
+public class BroadcastMessageDispatcher implements MessageDispatcher
+{
+    private final List<MessageDispatcher> dispatchers = new ArrayList<MessageDispatcher>();
+
+    @Override
+    public int dispatch(
+                 int partition,
+                 long requestOffset,
+                 long messageOffset,
+                 DirectBuffer key,
+                 Function<DirectBuffer, DirectBuffer> supplyHeader,
+                 DirectBuffer value)
+    {
+        int result = 0;
+        for (int i = 0; i < dispatchers.size(); i++)
+        {
+            MessageDispatcher dispatcher = dispatchers.get(i);
+            result += dispatcher.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+        }
+        return result;
+    }
+
+    @Override
+    public void flush(
+            int partition,
+            long requestOffset,
+            long lastOffset)
+    {
+        for (int i = 0; i < dispatchers.size(); i++)
+        {
+            MessageDispatcher dispatcher = dispatchers.get(i);
+            dispatcher.flush(partition, requestOffset, lastOffset);
+        }
+    }
+
+    public void add(MessageDispatcher dispatcher)
+    {
+         dispatchers.add(dispatcher);
+    }
+
+    public boolean remove(MessageDispatcher dispatcher)
+    {
+        return dispatchers.remove(dispatcher);
+    }
+
+    public boolean isEmpty()
+    {
+        return dispatchers.isEmpty();
+    }
+
+}

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcher.java
@@ -72,4 +72,10 @@ public class BroadcastMessageDispatcher implements MessageDispatcher
         return dispatchers.isEmpty();
     }
 
+    @Override
+    public String toString()
+    {
+        return String.format("%s(%s)", this.getClass().getSimpleName(), dispatchers);
+    }
+
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcher.java
@@ -32,13 +32,14 @@ public class BroadcastMessageDispatcher implements MessageDispatcher
                  long messageOffset,
                  DirectBuffer key,
                  Function<DirectBuffer, DirectBuffer> supplyHeader,
+                 long timestamp,
                  DirectBuffer value)
     {
         int result = 0;
         for (int i = 0; i < dispatchers.size(); i++)
         {
             MessageDispatcher dispatcher = dispatchers.get(i);
-            result += dispatcher.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+            result += dispatcher.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, timestamp, value);
         }
         return result;
     }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -90,9 +90,6 @@ public final class ClientStreamFactory implements StreamFactory
     private final OctetsFW messageKeyRO = new OctetsFW();
     private final OctetsFW messageValueRO = new OctetsFW();
 
-    private final DirectBuffer messageKeyBuffer = new UnsafeBuffer(EMPTY_BYTE_ARRAY);
-    private final DirectBuffer messageValueBuffer = new UnsafeBuffer(EMPTY_BYTE_ARRAY);
-
     final RouteManager router;
     final LongSupplier supplyStreamId;
     final LongSupplier supplyCorrelationId;
@@ -403,6 +400,9 @@ public final class ClientStreamFactory implements StreamFactory
         private final long applicationId;
         private final NetworkConnectionPool networkPool;
         private final Long2LongHashMap fetchOffsets;
+
+        private final DirectBuffer messageKeyBuffer = new UnsafeBuffer(EMPTY_BYTE_ARRAY);
+        private final DirectBuffer messageValueBuffer = new UnsafeBuffer(EMPTY_BYTE_ARRAY);
 
         private String applicationName;
         private long applicationCorrelationId;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcher.java
@@ -139,9 +139,6 @@ public class HeaderValueMessageDispatcher implements MessageDispatcher
         boolean first = true;
         for (Map.Entry<DirectBuffer, V> entry : map.entrySet())
         {
-            result.append(entry.getKey().getStringWithoutLengthUtf8(0, entry.getKey().capacity()));
-            result.append("=");
-            result.append(entry.getValue().toString());
             if (first)
             {
                 first = false;
@@ -150,6 +147,9 @@ public class HeaderValueMessageDispatcher implements MessageDispatcher
             {
                 result.append(", ");
             }
+            result.append(entry.getKey().getStringWithoutLengthUtf8(0, entry.getKey().capacity()));
+            result.append("=");
+            result.append(entry.getValue().toString());
         }
         result.append("}");
         return result.toString();

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcher.java
@@ -128,7 +128,31 @@ public class HeaderValueMessageDispatcher implements MessageDispatcher
     public String toString()
     {
         return String.format("%s(%s, %s)", this.getClass().getSimpleName(), new String(headerName.byteArray()),
-                dispatchersByHeaderValue);
+                toString(dispatchersByHeaderValue));
+    }
+
+    private <V> String toString(
+        Map<DirectBuffer, V> map)
+    {
+        StringBuffer result = new StringBuffer(1000);
+        result.append("{");
+        boolean first = true;
+        for (Map.Entry<DirectBuffer, V> entry : map.entrySet())
+        {
+            result.append(entry.getKey().getStringWithoutLengthUtf8(0, entry.getKey().capacity()));
+            result.append("=");
+            result.append(entry.getValue().toString());
+            if (first)
+            {
+                first = false;
+            }
+            else
+            {
+                result.append(", ");
+            }
+        }
+        result.append("}");
+        return result.toString();
     }
 
     public boolean isEmpty()

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcher.java
@@ -47,6 +47,7 @@ public class HeaderValueMessageDispatcher implements MessageDispatcher
              long messageOffset,
              DirectBuffer key,
              Function<DirectBuffer, DirectBuffer> supplyHeader,
+             long timestamp,
              DirectBuffer value)
     {
         int result = 0;
@@ -57,7 +58,7 @@ public class HeaderValueMessageDispatcher implements MessageDispatcher
             MessageDispatcher dispatcher = dispatchersByHeaderValue.get(buffer);
             if (dispatcher != null)
             {
-                result =  dispatcher.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+                result =  dispatcher.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, timestamp, value);
             }
         }
         return result;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcher.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.reaktivity.nukleus.kafka.internal.types.ListFW;
+import org.reaktivity.nukleus.kafka.internal.types.OctetsFW;
+import org.reaktivity.nukleus.kafka.internal.types.stream.KafkaHeaderFW;
+
+public class HeaderValueMessageDispatcher implements MessageDispatcher
+{
+    private final UnsafeBuffer buffer = new UnsafeBuffer(new byte[0]);
+    private final DirectBuffer headerName;
+
+    private Map<DirectBuffer, HeadersMessageDispatcher> dispatchersByHeaderValue = new HashMap<>();
+    private ArrayList<HeadersMessageDispatcher> dispatchers = new ArrayList<HeadersMessageDispatcher>();
+
+    public HeaderValueMessageDispatcher(DirectBuffer headerKey)
+    {
+        this.headerName = headerKey;
+    }
+
+    @Override
+    public
+    int dispatch(
+             int partition,
+             long requestOffset,
+             long messageOffset,
+             DirectBuffer key,
+             Function<DirectBuffer, DirectBuffer> supplyHeader,
+             DirectBuffer value)
+    {
+        int result = 0;
+        DirectBuffer header = supplyHeader.apply(headerName);
+        if (header != null)
+        {
+            buffer.wrap(header);
+            MessageDispatcher dispatcher = dispatchersByHeaderValue.get(buffer);
+            if (dispatcher != null)
+            {
+                result =  dispatcher.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void flush(
+            int partition,
+            long requestOffset,
+            long lastOffset)
+    {
+        for (int i = 0; i < dispatchers.size(); i++)
+        {
+            MessageDispatcher dispatcher = dispatchers.get(i);
+            dispatcher.flush(partition, requestOffset, lastOffset);
+        }
+    }
+
+    public void add(
+            OctetsFW headerValue,
+            ListFW<KafkaHeaderFW> headers,
+            int index,
+            MessageDispatcher dispatcher)
+    {
+        buffer.wrap(headerValue.buffer(), headerValue.offset(), headerValue.sizeof());
+        HeadersMessageDispatcher headersDispatcher = dispatchersByHeaderValue.get(buffer);
+        if (headersDispatcher == null)
+        {
+            UnsafeBuffer keyCopy = new UnsafeBuffer(new byte[headerValue.sizeof()]);
+            keyCopy.putBytes(0,  headerValue.buffer(), headerValue.offset(), headerValue.sizeof());
+            headersDispatcher =  new HeadersMessageDispatcher();
+            dispatchersByHeaderValue.put(keyCopy, headersDispatcher);
+            dispatchers.add(headersDispatcher);
+        }
+        headersDispatcher.add(headers, index, dispatcher);
+    }
+
+    public boolean remove(
+            OctetsFW headerValue,
+            ListFW<KafkaHeaderFW> headers,
+            int index,
+            MessageDispatcher dispatcher)
+    {
+        boolean result = false;
+        buffer.wrap(headerValue.buffer(), headerValue.offset(), headerValue.sizeof());
+        HeadersMessageDispatcher headersDispatcher = dispatchersByHeaderValue.get(buffer);
+        if (headersDispatcher != null)
+        {
+            result = headersDispatcher.remove(headers, index, dispatcher);
+            if (headersDispatcher.isEmpty())
+            {
+                dispatchersByHeaderValue.remove(buffer);
+                dispatchers.remove(headersDispatcher);
+            }
+        }
+        return result;
+    }
+
+    public HeadersMessageDispatcher get(
+            OctetsFW headerValue)
+    {
+        buffer.wrap(headerValue.buffer(), headerValue.offset(), headerValue.sizeof());
+        return dispatchersByHeaderValue.get(buffer);
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s(%s, %s)", this.getClass().getSimpleName(), new String(headerName.byteArray()),
+                dispatchersByHeaderValue);
+    }
+
+    public boolean isEmpty()
+    {
+         return dispatchersByHeaderValue.isEmpty();
+    }
+
+}

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeadersMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeadersMessageDispatcher.java
@@ -41,14 +41,15 @@ public class HeadersMessageDispatcher implements MessageDispatcher
                  long messageOffset,
                  DirectBuffer key,
                  Function<DirectBuffer, DirectBuffer> supplyHeader,
+                 long timestamp,
                  DirectBuffer value)
     {
         int result = 0;
-        result +=  broadcast.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+        result +=  broadcast.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, timestamp, value);
         for (int i = 0; i < dispatchers.size(); i++)
         {
             MessageDispatcher dispatcher = dispatchers.get(i);
-            result += dispatcher.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+            result += dispatcher.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, timestamp, value);
         }
         return result;
     }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeadersMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeadersMessageDispatcher.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.reaktivity.nukleus.kafka.internal.types.ListFW;
+import org.reaktivity.nukleus.kafka.internal.types.String16FW;
+import org.reaktivity.nukleus.kafka.internal.types.stream.KafkaHeaderFW;
+
+public class HeadersMessageDispatcher implements MessageDispatcher
+{
+    private final UnsafeBuffer buffer = new UnsafeBuffer(new byte[0]);
+    private final Map<DirectBuffer, HeaderValueMessageDispatcher> dispatchersByHeaderKey = new HashMap<>();
+    private final List<HeaderValueMessageDispatcher> dispatchers = new ArrayList<HeaderValueMessageDispatcher>();
+    private final BroadcastMessageDispatcher broadcast = new BroadcastMessageDispatcher();
+
+    @Override
+    public int dispatch(
+                 int partition,
+                 long requestOffset,
+                 long messageOffset,
+                 DirectBuffer key,
+                 Function<DirectBuffer, DirectBuffer> supplyHeader,
+                 DirectBuffer value)
+    {
+        int result = 0;
+        result +=  broadcast.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+        for (int i = 0; i < dispatchers.size(); i++)
+        {
+            MessageDispatcher dispatcher = dispatchers.get(i);
+            result += dispatcher.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+        }
+        return result;
+    }
+
+    @Override
+    public void flush(
+            int partition,
+            long requestOffset,
+            long lastOffset)
+    {
+        broadcast.flush(partition, requestOffset, lastOffset);
+        for (int i = 0; i < dispatchers.size(); i++)
+        {
+            MessageDispatcher dispatcher = dispatchers.get(i);
+            dispatcher.flush(partition, requestOffset, lastOffset);
+        }
+    }
+
+    public HeadersMessageDispatcher add(
+                ListFW<KafkaHeaderFW> headers,
+                int index,
+                MessageDispatcher dispatcher)
+    {
+        final int[] counter = new int[]{0};
+        final KafkaHeaderFW header = headers == null ? null : headers.matchFirst(h -> (index == counter[0]++));
+        if (header == null)
+        {
+            broadcast.add(dispatcher);
+        }
+        else
+        {
+            String16FW headerKey = header.key();
+            int valueOffset = headerKey.offset() + Short.BYTES;
+            int valueLength = headerKey.limit() - valueOffset;
+            buffer.wrap(headerKey.buffer(), valueOffset, valueLength);
+            HeaderValueMessageDispatcher valueDispatcher = dispatchersByHeaderKey.get(buffer);
+            if (valueDispatcher == null)
+            {
+                int bytesLength = headerKey.sizeof() - Short.BYTES;
+                UnsafeBuffer keyCopy = new UnsafeBuffer(new byte[bytesLength]);
+                keyCopy.putBytes(0, headerKey.buffer(), valueOffset, valueLength);
+                valueDispatcher = new HeaderValueMessageDispatcher(keyCopy);
+                dispatchersByHeaderKey.put(keyCopy, valueDispatcher);
+                dispatchers.add(valueDispatcher);
+            }
+            valueDispatcher.add(header.value(), headers, index + 1, dispatcher);
+        }
+        return this;
+    }
+
+    public boolean isEmpty()
+     {
+
+         return broadcast.isEmpty() && dispatchersByHeaderKey.isEmpty();
+     }
+
+    public boolean remove(
+            ListFW<KafkaHeaderFW> headers,
+            int index,
+            MessageDispatcher dispatcher)
+    {
+        boolean result = false;
+        final int[] counter = new int[]{0};
+        final KafkaHeaderFW header = headers == null ? null : headers.matchFirst(h -> (index == counter[0]++));
+        if (header == null)
+        {
+            result = broadcast.remove(dispatcher);
+        }
+        else
+        {
+            String16FW headerKey = header.key();
+            int valueOffset = headerKey.offset() + Short.BYTES;
+            int valueLength = headerKey.limit() - valueOffset;
+            buffer.wrap(headerKey.buffer(), valueOffset, valueLength);
+            HeaderValueMessageDispatcher valueDispatcher = dispatchersByHeaderKey.get(buffer);
+            if (valueDispatcher != null)
+            {
+                result = valueDispatcher.remove(header.value(), headers, index + 1, dispatcher);
+                if (valueDispatcher.isEmpty())
+                {
+                    dispatchersByHeaderKey.remove(buffer);
+                    dispatchers.remove(valueDispatcher);
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s(%s)", this.getClass().getSimpleName(), dispatchersByHeaderKey);
+    }
+
+}
+

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeadersMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeadersMessageDispatcher.java
@@ -141,7 +141,23 @@ public class HeadersMessageDispatcher implements MessageDispatcher
     @Override
     public String toString()
     {
-        return String.format("%s(%s)", this.getClass().getSimpleName(), dispatchersByHeaderKey);
+        return String.format("%s(%s, %s)", this.getClass().getSimpleName(), broadcast, toString(dispatchersByHeaderKey));
+    }
+
+    private <V> String toString(
+        Map<DirectBuffer, V> map)
+    {
+        StringBuffer result = new StringBuffer(1000);
+        result.append('{');
+        for (Map.Entry<DirectBuffer, V> entry : map.entrySet())
+        {
+            result.append('\n');
+            result.append(entry.getKey().getStringWithoutLengthUtf8(0, entry.getKey().capacity()));
+            result.append(" = ");
+            result.append(entry.getValue().toString());
+        }
+        result.append('}');
+        return result.toString();
     }
 
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcher.java
@@ -38,12 +38,13 @@ public class KeyMessageDispatcher implements MessageDispatcher
                  long messageOffset,
                  DirectBuffer key,
                  Function<DirectBuffer, DirectBuffer> supplyHeader,
+                 long timestamp,
                  DirectBuffer value)
     {
         buffer.wrap(key, 0, key.capacity());
         MessageDispatcher result = dispatchersByKey.get(buffer);
         return result == null ? 0 :
-            result.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+            result.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, timestamp, value);
     }
 
     @Override

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcher.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.reaktivity.nukleus.kafka.internal.types.ListFW;
+import org.reaktivity.nukleus.kafka.internal.types.OctetsFW;
+import org.reaktivity.nukleus.kafka.internal.types.stream.KafkaHeaderFW;
+
+public class KeyMessageDispatcher implements MessageDispatcher
+{
+    private final UnsafeBuffer buffer = new UnsafeBuffer(new byte[0]);
+
+    private Map<UnsafeBuffer, HeadersMessageDispatcher> dispatchersByKey = new HashMap<>();
+
+    @Override
+    public int dispatch(
+                 int partition,
+                 long requestOffset,
+                 long messageOffset,
+                 DirectBuffer key,
+                 Function<DirectBuffer, DirectBuffer> supplyHeader,
+                 DirectBuffer value)
+    {
+        buffer.wrap(key, 0, key.capacity());
+        MessageDispatcher result = dispatchersByKey.get(buffer);
+        return result == null ? 0 :
+            result.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+    }
+
+    @Override
+    public void flush(
+            int partition,
+            long requestOffset,
+            long lastOffset)
+    {
+        for (MessageDispatcher dispatcher: dispatchersByKey.values())
+        {
+            dispatcher.flush(partition, requestOffset, lastOffset);
+        }
+    }
+
+    public void add(OctetsFW key, ListFW<KafkaHeaderFW> headers, MessageDispatcher dispatcher)
+    {
+        buffer.wrap(key.buffer(), key.offset(), key.sizeof());
+        HeadersMessageDispatcher existing = dispatchersByKey.get(buffer);
+        if (existing == null)
+        {
+            UnsafeBuffer keyCopy = new UnsafeBuffer(new byte[key.sizeof()]);
+            keyCopy.putBytes(0,  key.buffer(), key.offset(), key.sizeof());
+            existing = new HeadersMessageDispatcher();
+            dispatchersByKey.put(keyCopy, existing);
+        }
+        existing.add(headers, 0, dispatcher);
+    }
+
+    public boolean remove(OctetsFW key, ListFW<KafkaHeaderFW> headers, MessageDispatcher dispatcher)
+    {
+        boolean result = false;
+        buffer.wrap(key.buffer(), key.offset(), key.sizeof());
+        HeadersMessageDispatcher headersDispatcher = dispatchersByKey.get(buffer);
+        if (headersDispatcher != null)
+        {
+            result = headersDispatcher.remove(headers, 0, dispatcher);
+            if (headersDispatcher.isEmpty())
+            {
+                dispatchersByKey.remove(buffer);
+            }
+        }
+        return result;
+    }
+
+    public boolean isEmpty()
+    {
+        return dispatchersByKey.isEmpty();
+    }
+
+}

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcher.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import java.util.function.Function;
+
+import org.agrona.DirectBuffer;
+
+public interface MessageDispatcher
+{
+
+    int dispatch(
+             int partition,
+             long requestOffset,
+             long messageOffset,
+             DirectBuffer key,
+             Function<DirectBuffer, DirectBuffer> supplyHeader,
+             DirectBuffer value);
+
+    void flush(
+            int partition,
+            long requestOffset,
+            long lastOffset);
+
+}

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -51,9 +51,10 @@ import org.agrona.collections.Long2LongHashMap.LongIterator;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.reaktivity.nukleus.buffer.BufferPool;
 import org.reaktivity.nukleus.function.MessageConsumer;
+import org.reaktivity.nukleus.kafka.internal.function.IntBooleanConsumer;
 import org.reaktivity.nukleus.kafka.internal.function.PartitionProgressHandler;
-import org.reaktivity.nukleus.kafka.internal.function.PartitionResponseConsumer;
 import org.reaktivity.nukleus.kafka.internal.types.Flyweight;
+import org.reaktivity.nukleus.kafka.internal.types.ListFW;
 import org.reaktivity.nukleus.kafka.internal.types.OctetsFW;
 import org.reaktivity.nukleus.kafka.internal.types.String16FW;
 import org.reaktivity.nukleus.kafka.internal.types.codec.RequestHeaderFW;
@@ -65,8 +66,11 @@ import org.reaktivity.nukleus.kafka.internal.types.codec.config.ResourceRequestF
 import org.reaktivity.nukleus.kafka.internal.types.codec.config.ResourceResponseFW;
 import org.reaktivity.nukleus.kafka.internal.types.codec.fetch.FetchRequestFW;
 import org.reaktivity.nukleus.kafka.internal.types.codec.fetch.FetchResponseFW;
+import org.reaktivity.nukleus.kafka.internal.types.codec.fetch.HeaderFW;
 import org.reaktivity.nukleus.kafka.internal.types.codec.fetch.PartitionRequestFW;
 import org.reaktivity.nukleus.kafka.internal.types.codec.fetch.PartitionResponseFW;
+import org.reaktivity.nukleus.kafka.internal.types.codec.fetch.RecordBatchFW;
+import org.reaktivity.nukleus.kafka.internal.types.codec.fetch.RecordFW;
 import org.reaktivity.nukleus.kafka.internal.types.codec.fetch.RecordSetFW;
 import org.reaktivity.nukleus.kafka.internal.types.codec.fetch.TopicRequestFW;
 import org.reaktivity.nukleus.kafka.internal.types.codec.fetch.TopicResponseFW;
@@ -80,6 +84,7 @@ import org.reaktivity.nukleus.kafka.internal.types.stream.AbortFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.BeginFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.DataFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.EndFW;
+import org.reaktivity.nukleus.kafka.internal.types.stream.KafkaHeaderFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.ResetFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.TcpBeginExFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.WindowFW;
@@ -102,6 +107,8 @@ final class NetworkConnectionPool
 
     private static final int MAX_MESSAGE_SIZE = 10000;
 
+    static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+
     final RequestHeaderFW.Builder requestRW = new RequestHeaderFW.Builder();
     final FetchRequestFW.Builder fetchRequestRW = new FetchRequestFW.Builder();
     final TopicRequestFW.Builder topicRequestRW = new TopicRequestFW.Builder();
@@ -120,6 +127,13 @@ final class NetworkConnectionPool
     final TopicResponseFW topicResponseRO = new TopicResponseFW();
     final PartitionResponseFW partitionResponseRO = new PartitionResponseFW();
     final RecordSetFW recordSetRO = new RecordSetFW();
+
+    private final RecordBatchFW recordBatchRO = new RecordBatchFW();
+    private final RecordFW recordRO = new RecordFW();
+    private final HeaderFW headerRO = new HeaderFW();
+
+    private final UnsafeBuffer keyBuffer = new UnsafeBuffer(EMPTY_BYTE_ARRAY);
+    private final UnsafeBuffer valueBuffer = new UnsafeBuffer(EMPTY_BYTE_ARRAY);
 
     final MetadataResponseFW metadataResponseRO = new MetadataResponseFW();
     final BrokerMetadataFW brokerMetadataRO = new BrokerMetadataFW();
@@ -169,34 +183,20 @@ final class NetworkConnectionPool
     void doAttach(
         String topicName,
         Long2LongHashMap fetchOffsets,
-        PartitionResponseConsumer consumeRecords,
-        IntSupplier supplyWindow,
-        IntConsumer newAttachIdConsumer,
-        IntConsumer onMetadataError)
-    {
-        final TopicMetadata metadata = topicMetadataByName.computeIfAbsent(topicName, TopicMetadata::new);
-        metadata.doAttach((m) ->
-        {
-            doAttach(topicName, fetchOffsets, consumeRecords, supplyWindow, newAttachIdConsumer, onMetadataError, m);
-        });
-
-        metadataConnection.doRequestIfNeeded();
-    }
-
-    void doAttach(
-        String topicName,
-        Long2LongHashMap fetchOffsets,
         int partitionHash,
-        PartitionResponseConsumer consumeRecords,
+        OctetsFW fetchKey,
+        ListFW<KafkaHeaderFW> headers,
+        MessageDispatcher dispatcher,
         IntSupplier supplyWindow,
-        IntConsumer newAttachIdConsumer,
+        Consumer<PartitionProgressHandler> progressHandlerConsumer,
+        IntBooleanConsumer newAttachDetailsConsumer,
         IntConsumer onMetadataError)
     {
         final TopicMetadata metadata = topicMetadataByName.computeIfAbsent(topicName, TopicMetadata::new);
         metadata.doAttach((m) ->
         {
-            doAttach(topicName, fetchOffsets, partitionHash, consumeRecords, supplyWindow, newAttachIdConsumer,
-                    onMetadataError, m);
+            doAttach(topicName, fetchOffsets, partitionHash,  fetchKey, headers, dispatcher, supplyWindow,
+                    progressHandlerConsumer, newAttachDetailsConsumer, onMetadataError, m);
         });
 
         metadataConnection.doRequestIfNeeded();
@@ -205,9 +205,13 @@ final class NetworkConnectionPool
     private void doAttach(
         String topicName,
         Long2LongHashMap fetchOffsets,
-        PartitionResponseConsumer consumeRecords,
+        int partitionHash,
+        OctetsFW fetchKey,
+        ListFW<KafkaHeaderFW> headers,
+        MessageDispatcher dispatcher,
         IntSupplier supplyWindow,
-        IntConsumer newAttachIdConsumer,
+        Consumer<PartitionProgressHandler> progressHandlerConsumer,
+        IntBooleanConsumer newAttachDetailsConsumer,
         IntConsumer onMetadataError,
         TopicMetadata topicMetadata)
     {
@@ -224,48 +228,25 @@ final class NetworkConnectionPool
             // recoverable
             break;
         case NONE:
-            while(fetchOffsets.size() < topicMetadata.partitionCount())
+            if (fetchKey != null)
             {
-                fetchOffsets.put(fetchOffsets.size(), 0L);
+                int partitionId = BufferUtil.partition(partitionHash, topicMetadata.partitionCount());
+                fetchOffsets.computeIfAbsent(0L, v -> 0L);
+                if (partitionId != 0)
+                {
+                    long offset = fetchOffsets.remove(0L);
+                    fetchOffsets.put(partitionId, offset);
+                }
             }
-            finishAttach(topicName, fetchOffsets, consumeRecords, supplyWindow, newAttachIdConsumer, topicMetadata);
-            break;
-        default:
-            throw new RuntimeException(format("Unexpected errorCode %d from metadata query", errorCode));
-        }
-    }
-
-    private void doAttach(
-        String topicName,
-        Long2LongHashMap fetchOffsets,
-        int partitionHash,
-        PartitionResponseConsumer consumeRecords,
-        IntSupplier supplyWindow,
-        IntConsumer newAttachIdConsumer,
-        IntConsumer onMetadataError,
-        TopicMetadata topicMetadata)
-    {
-        short errorCode = topicMetadata.errorCode();
-        switch(errorCode)
-        {
-        case UNKNOWN_TOPIC_OR_PARTITION:
-            onMetadataError.accept(errorCode);
-            break;
-        case INVALID_TOPIC_EXCEPTION:
-            onMetadataError.accept(errorCode);
-            break;
-        case LEADER_NOT_AVAILABLE:
-            // recoverable
-            break;
-        case NONE:
-            int partitionId = BufferUtil.partition(partitionHash, topicMetadata.partitionCount());
-            fetchOffsets.computeIfAbsent(0L, v -> 0L);
-            if (partitionId != 0)
+            else
             {
-                long offset = fetchOffsets.remove(0L);
-                fetchOffsets.put(partitionId, offset);
+                while(fetchOffsets.size() < topicMetadata.partitionCount())
+                {
+                    fetchOffsets.put(fetchOffsets.size(), 0L);
+                }
             }
-            finishAttach(topicName, fetchOffsets, consumeRecords, supplyWindow, newAttachIdConsumer, topicMetadata);
+            finishAttach(topicName, fetchOffsets, fetchKey, headers, dispatcher, supplyWindow,
+                    progressHandlerConsumer, newAttachDetailsConsumer, topicMetadata);
             break;
         default:
             throw new RuntimeException(format("Unexpected errorCode %d from metadata query", errorCode));
@@ -275,18 +256,21 @@ final class NetworkConnectionPool
     private void finishAttach(
         String topicName,
         Long2LongHashMap fetchOffsets,
-        PartitionResponseConsumer consumeRecords,
+        OctetsFW fetchKey,
+        ListFW<KafkaHeaderFW> headers,
+        MessageDispatcher dispatcher,
         IntSupplier supplyWindow,
-        IntConsumer newAttachIdConsumer,
+        Consumer<PartitionProgressHandler> progressHandlerConsumer,
+        IntBooleanConsumer newAttachDetailsConsumer,
         TopicMetadata topicMetadata)
     {
         final NetworkTopic topic = topicsByName.computeIfAbsent(topicName,
-                name -> new NetworkTopic(name, topicMetadata.isCompacted()));
-        topic.doAttach(fetchOffsets, consumeRecords, supplyWindow);
+                name -> new NetworkTopic(name));
+        progressHandlerConsumer.accept(topic.doAttach(fetchOffsets, fetchKey, headers, dispatcher, supplyWindow));
 
         final int newAttachId = nextAttachId++;
 
-        detachersById.put(newAttachId, f -> topic.doDetach(f, consumeRecords, supplyWindow));
+        detachersById.put(newAttachId, f -> topic.doDetach(f, fetchKey, headers, dispatcher, supplyWindow));
 
         topicMetadata.visitBrokers(broker ->
         {
@@ -296,7 +280,8 @@ final class NetworkConnectionPool
         {
             historicalConnections = applyBrokerMetadata(historicalConnections, broker,  HistoricalFetchConnection::new);
         });
-        newAttachIdConsumer.accept(newAttachId);
+        newAttachDetailsConsumer.accept(newAttachId, topicMetadata.compacted);
+        doFlush();
     }
 
     private <T extends AbstractFetchConnection> T[] applyBrokerMetadata(
@@ -328,8 +313,7 @@ final class NetworkConnectionPool
         return result;
     }
 
-    void doFlush(
-        long connectionPoolAttachId)
+    void doFlush()
     {
         for (AbstractFetchConnection connection  : connections)
         {
@@ -1260,14 +1244,21 @@ final class NetworkConnectionPool
     private final class NetworkTopic
     {
         private final String topicName;
-        private final boolean compacted;
-        private final Set<PartitionResponseConsumer> recordConsumers;
         private final Set<IntSupplier> windowSuppliers;
         final NavigableSet<NetworkTopicPartition> partitions;
         private final NetworkTopicPartition candidate;
+        private final TopicMessageDispatcher dispatcher = new TopicMessageDispatcher();
         private final PartitionProgressHandler progressHandler;
 
         private BitSet needsHistoricalByPartition = new BitSet();
+
+        // Transient, on stack state
+        private int headersOffset;
+        private int headersLimit;
+        private DirectBuffer headersBuffer;
+        private UnsafeBuffer header = new UnsafeBuffer(EMPTY_BYTE_ARRAY);
+        private UnsafeBuffer value1 = new UnsafeBuffer(EMPTY_BYTE_ARRAY);
+        private UnsafeBuffer value2 = new UnsafeBuffer(EMPTY_BYTE_ARRAY);
 
         @Override
         public String toString()
@@ -1276,38 +1267,37 @@ final class NetworkConnectionPool
         }
 
         NetworkTopic(
-            String topicName, boolean compacted)
+            String topicName)
         {
             this.topicName = topicName;
-            this.compacted = compacted;
-            this.recordConsumers = new HashSet<>();
             this.windowSuppliers = new HashSet<>();
             this.partitions = new TreeSet<>();
             this.candidate = new NetworkTopicPartition();
             this.progressHandler = this::handleProgress;
         }
 
-        void doAttach(
+        PartitionProgressHandler doAttach(
             Long2LongHashMap fetchOffsets,
-            PartitionResponseConsumer consumeRecords,
+            OctetsFW fetchKey,
+            ListFW<KafkaHeaderFW> headers,
+            MessageDispatcher dispatcher,
             IntSupplier supplyWindow)
         {
-            recordConsumers.add(consumeRecords);
             windowSuppliers.add(supplyWindow);
+            this.dispatcher.add(fetchKey, headers, dispatcher);
 
             final LongIterator keys = fetchOffsets.keySet().iterator();
             while (keys.hasNext())
             {
                 final long partitionId = (int) keys.nextValue();
-                attachToPartition((int) partitionId, fetchOffsets.get(partitionId), consumeRecords, supplyWindow);
+                attachToPartition((int) partitionId, fetchOffsets.get(partitionId));
             }
+             return progressHandler;
         }
 
         private void attachToPartition(
             int partitionId,
-            long fetchOffset,
-            PartitionResponseConsumer consumeRecords,
-            IntSupplier supplyWindow)
+            long fetchOffset)
         {
             candidate.id = partitionId;
             candidate.offset = fetchOffset;
@@ -1328,33 +1318,31 @@ final class NetworkConnectionPool
 
         void doDetach(
             Long2LongHashMap fetchOffsets,
-            PartitionResponseConsumer consumeRecords,
+            OctetsFW fetchKey,
+            ListFW<KafkaHeaderFW> headers,
+            MessageDispatcher dispatcher,
             IntSupplier supplyWindow)
         {
-            recordConsumers.remove(consumeRecords);
             windowSuppliers.remove(supplyWindow);
-
+            this.dispatcher.remove(fetchKey, headers, dispatcher);
             final LongIterator partitionIds = fetchOffsets.keySet().iterator();
             while (partitionIds.hasNext())
             {
                 long partitionId = partitionIds.nextValue();
-                doDetach((int) partitionId, fetchOffsets.get(partitionId), consumeRecords, supplyWindow);
+                doDetach((int) partitionId, fetchOffsets.get(partitionId), supplyWindow);
             }
             if (partitions.isEmpty())
             {
                 topicsByName.remove(topicName);
                 topicMetadataByName.remove(topicName);
-
             }
         }
 
         void doDetach(
             int partitionId,
             long fetchOffset,
-            PartitionResponseConsumer consumeRecords,
             IntSupplier supplyWindow)
         {
-            recordConsumers.remove(consumeRecords);
             windowSuppliers.remove(supplyWindow);
             candidate.id = partitionId;
             candidate.offset = fetchOffset;
@@ -1393,17 +1381,89 @@ final class NetworkConnectionPool
 
         void onPartitionResponse(
             DirectBuffer buffer,
-            int index,
+            int offset,
             int length,
             long requestedOffset)
         {
-            // TODO: parse here, callback for individual records only
-            //       via RecordConsumer.accept(buffer, index, length, baseOffset, progressHandler)
+            final int maxLimit = offset + length;
+            int networkOffset = offset;
+            final PartitionResponseFW partition = partitionResponseRO.wrap(buffer, networkOffset, maxLimit);
+            networkOffset = partition.limit();
+            final int partitionId = partition.partitionId();
 
-            // TODO: eliminate iterator allocation
-            for (PartitionResponseConsumer recordsConsumer : recordConsumers)
+            // TODO: determine appropriate reaction to different non-zero error codes
+            if (partition.errorCode() == 0 && networkOffset < maxLimit - BitUtil.SIZE_OF_INT)
             {
-                recordsConsumer.accept(buffer, index, length, requestedOffset, compacted, progressHandler);
+                final RecordSetFW recordSet = recordSetRO.wrap(buffer, networkOffset, maxLimit);
+                networkOffset = recordSet.limit();
+
+                final int recordSetLimit = networkOffset + recordSet.recordBatchSize();
+                if (recordSetLimit <= maxLimit)
+                {
+                    loop:
+                    while (networkOffset < recordSetLimit - RecordBatchFW.FIELD_OFFSET_RECORD_COUNT - BitUtil.SIZE_OF_INT)
+                    {
+                        final RecordBatchFW recordBatch = recordBatchRO.wrap(buffer, networkOffset, recordSetLimit);
+                        networkOffset = recordBatch.limit();
+
+                        final int recordBatchLimit = recordBatch.offset() +
+                                RecordBatchFW.FIELD_OFFSET_LENGTH + BitUtil.SIZE_OF_INT + recordBatch.length();
+                        if (recordBatchLimit > recordSetLimit)
+                        {
+                            break loop;
+                        }
+
+                        final long firstOffset = recordBatch.firstOffset();
+                        final long firstTimestamp = recordBatch.firstTimestamp();
+                        long nextFetchAt = firstOffset;
+                        while (networkOffset < recordBatchLimit - 7 /* minimum RecordFW size */)
+                        {
+                            final RecordFW record = recordRO.wrap(buffer, networkOffset, recordBatchLimit);
+                            networkOffset = record.limit();
+                            final int recordLimit = record.offset() +
+                                    RecordFW.FIELD_OFFSET_ATTRIBUTES + record.length();
+                            if (recordLimit > recordSetLimit)
+                            {
+                                break loop;
+                            }
+
+                            headersOffset = networkOffset;
+                            final int headerCount = record.headerCount();
+                            for (int i = 0; i < headerCount; i++)
+                            {
+                                final HeaderFW header = headerRO.wrap(buffer, networkOffset, recordBatchLimit);
+                                networkOffset = header.limit();
+                            }
+                            headersLimit = networkOffset;
+                            headersBuffer = buffer;
+
+                            final long currentFetchAt = firstOffset + record.offsetDelta();
+
+                            nextFetchAt = currentFetchAt + 1;
+
+                            DirectBuffer key = null;
+                            final OctetsFW messageKey = record.key();
+                            if (messageKey != null)
+                            {
+                                keyBuffer.wrap(messageKey.buffer(), messageKey.offset(), messageKey.sizeof());
+                                key = keyBuffer;
+                            }
+
+                            final long timestamp = firstTimestamp + record.timestampDelta();
+
+                            DirectBuffer value = null;
+                            final OctetsFW messageValue = record.value();
+                            if (messageValue != null)
+                            {
+                                valueBuffer.wrap(messageValue.buffer(), messageValue.offset(), messageValue.sizeof());
+                                value = valueBuffer;
+                            }
+                            dispatcher.dispatch(partitionId, requestedOffset, nextFetchAt,
+                                         key, this::supplyHeader, timestamp, value);
+                        }
+                        dispatcher.flush(partitionId, requestedOffset, nextFetchAt);
+                    }
+                }
             }
         }
 
@@ -1451,6 +1511,13 @@ final class NetworkConnectionPool
             }
         }
 
+        private boolean matches(OctetsFW octets, DirectBuffer buffer)
+        {
+            value1.wrap(octets.buffer(), octets.offset(), octets.sizeof());
+            value2.wrap(buffer);
+            return value1.equals(value2);
+        }
+
         private void remove(
             NetworkTopicPartition partition)
         {
@@ -1479,6 +1546,26 @@ final class NetworkConnectionPool
         boolean needsHistorical(int partition)
         {
             return needsHistoricalByPartition.get(partition);
+        }
+
+        private DirectBuffer supplyHeader(DirectBuffer headerName)
+        {
+            DirectBuffer result = null;
+            if (headersLimit > headersOffset)
+            {
+                for (int offset = headersOffset; offset < headersLimit; offset = headerRO.limit())
+                {
+                    headerRO.wrap(headersBuffer, offset, headersLimit);
+                    if (matches(headerRO.key(), headerName))
+                    {
+                        OctetsFW value = headerRO.value();
+                        header.wrap(value.buffer(), value.offset(), value.sizeof());
+                        result = header;
+                        break;
+                    }
+                }
+            }
+            return result;
         }
     }
 
@@ -1555,12 +1642,7 @@ final class NetworkConnectionPool
             return brokers != null;
         }
 
-        public boolean isCompacted()
-        {
-            return compacted;
-        }
-
-        public void setCompacted(boolean compacted)
+        void setCompacted(boolean compacted)
         {
             this.compacted = compacted;
         }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcher.java
@@ -35,15 +35,16 @@ public class TopicMessageDispatcher implements MessageDispatcher
                  long messageOffset,
                  DirectBuffer key,
                  Function<DirectBuffer, DirectBuffer> supplyHeader,
+                 long timestamp,
                  DirectBuffer value)
     {
         int result = 0;
-        result += broadcast.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+        result += broadcast.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, timestamp, value);
         if (key != null)
         {
-            result += keys.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+            result += keys.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, timestamp, value);
         }
-        result += headers.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+        result += headers.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, timestamp, value);
         return result;
     }
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcher.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import java.util.function.Function;
+
+import org.agrona.DirectBuffer;
+import org.reaktivity.nukleus.kafka.internal.types.ListFW;
+import org.reaktivity.nukleus.kafka.internal.types.OctetsFW;
+import org.reaktivity.nukleus.kafka.internal.types.stream.KafkaHeaderFW;
+
+public class TopicMessageDispatcher implements MessageDispatcher
+{
+    private final KeyMessageDispatcher keys = new KeyMessageDispatcher();
+    private final HeadersMessageDispatcher headers = new HeadersMessageDispatcher();
+    private final BroadcastMessageDispatcher broadcast = new BroadcastMessageDispatcher();
+
+    @Override
+    public int dispatch(
+                 int partition,
+                 long requestOffset,
+                 long messageOffset,
+                 DirectBuffer key,
+                 Function<DirectBuffer, DirectBuffer> supplyHeader,
+                 DirectBuffer value)
+    {
+        int result = 0;
+        result += broadcast.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+        if (key != null)
+        {
+            result += keys.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+        }
+        result += headers.dispatch(partition, requestOffset, messageOffset, key, supplyHeader, value);
+        return result;
+    }
+
+    @Override
+    public void flush(
+            int partition,
+            long requestOffset,
+            long lastOffset)
+    {
+        broadcast.flush(partition, requestOffset, lastOffset);
+        keys.flush(partition, requestOffset, lastOffset);
+        headers.flush(partition, requestOffset, lastOffset);
+    }
+
+    public void add(OctetsFW fetchKey,
+                    ListFW<KafkaHeaderFW> headers,
+                    MessageDispatcher dispatcher)
+    {
+         if (fetchKey != null)
+         {
+             keys.add(fetchKey, headers, dispatcher);
+         }
+         else if (headers != null && !headers.isEmpty())
+         {
+             this.headers.add(headers, 0, dispatcher);
+         }
+         else
+         {
+             broadcast.add(dispatcher);
+         }
+    }
+
+    public boolean remove(OctetsFW fetchKey,
+                       ListFW<KafkaHeaderFW> headers,
+                       MessageDispatcher dispatcher)
+      {
+           boolean result = false;
+           if (fetchKey != null)
+           {
+               result = keys.remove(fetchKey, headers, dispatcher);
+           }
+           else if (headers != null && !headers.isEmpty())
+           {
+               result = this.headers.remove(headers, 0, dispatcher);
+           }
+           else
+           {
+               result = broadcast.remove(dispatcher);
+           }
+           return result;
+      }
+
+    public boolean isEmpty()
+    {
+        return keys.isEmpty() && headers.isEmpty() && broadcast.isEmpty();
+    }
+
+}

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcherTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.Function;
+
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.jmock.Expectations;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class BroadcastMessageDispatcherTest
+{
+    private BroadcastMessageDispatcher dispatcher = new BroadcastMessageDispatcher();
+
+    @Rule
+    public JUnitRuleMockery context = new JUnitRuleMockery();
+
+    @Test
+    public void shouldAddDispatchers()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        dispatcher.add(child1);
+        dispatcher.add(child2);
+    }
+
+    @Test
+    public void shouldDispatch()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        dispatcher.add(child1);
+        dispatcher.add(child2);
+        @SuppressWarnings("unchecked")
+        Function<DirectBuffer, DirectBuffer> header = context.mock(Function.class, "header");
+        context.checking(new Expectations()
+        {
+            {
+                oneOf(child1).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key")),
+                        with(header), with((DirectBuffer) null));
+                will(returnValue(1));
+                oneOf(child2).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key")),
+                        with(header),  with((DirectBuffer) null));
+                will(returnValue(1));
+            }
+        });
+        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, asBuffer("key"), header, null));
+    }
+
+    @Test
+    public void shouldFlush()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        dispatcher.add(child1);
+        dispatcher.add(child2);
+        context.checking(new Expectations()
+        {
+            {
+                oneOf(child1).flush(1, 10L, 12L);
+                oneOf(child2).flush(1, 10L, 12L);
+            }
+        });
+        dispatcher.flush(1, 10L, 12L);
+    }
+
+    @Test
+    public void shouldRemoveDispatcherWhenPresent()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        dispatcher.add(child1);
+        dispatcher.add(child2);
+        assertTrue(dispatcher.remove(child1));
+        assertTrue(dispatcher.remove(child2));
+    }
+
+    @Test
+    public void shouldNotRemoveDispatcherWhenNotPresent()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        MessageDispatcher another = context.mock(MessageDispatcher.class, "another");
+        dispatcher.add(child1);
+        dispatcher.add(child2);
+        assertFalse(dispatcher.remove(another));
+    }
+
+    private DirectBuffer asBuffer(String value)
+    {
+        byte[] bytes = value.getBytes(UTF_8);
+        return new UnsafeBuffer(bytes);
+    }
+
+    private Matcher<DirectBuffer> bufferMatching(final String string)
+    {
+        return new BaseMatcher<DirectBuffer>()
+        {
+
+            @Override
+            public boolean matches(Object item)
+            {
+                return item instanceof UnsafeBuffer &&
+                        ((UnsafeBuffer)item).equals(new UnsafeBuffer(string.getBytes(UTF_8)));
+            }
+
+            @Override
+            public void describeTo(Description description)
+            {
+                description.appendText(string);
+            }
+
+        };
+    }
+
+}

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcherTest.java
@@ -55,20 +55,21 @@ public final class BroadcastMessageDispatcherTest
         MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
         dispatcher.add(child1);
         dispatcher.add(child2);
+        final long timestamp = System.currentTimeMillis() - 123;
         @SuppressWarnings("unchecked")
         Function<DirectBuffer, DirectBuffer> header = context.mock(Function.class, "header");
         context.checking(new Expectations()
         {
             {
                 oneOf(child1).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key")),
-                        with(header), with((DirectBuffer) null));
+                        with(header), with(timestamp), with((DirectBuffer) null));
                 will(returnValue(1));
                 oneOf(child2).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key")),
-                        with(header),  with((DirectBuffer) null));
+                        with(header), with(timestamp), with((DirectBuffer) null));
                 will(returnValue(1));
             }
         });
-        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, asBuffer("key"), header, null));
+        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, asBuffer("key"), header, timestamp, null));
     }
 
     @Test

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package org.reaktivity.nukleus.kafka.internal.streams;
+package org.reaktivity.nukleus.kafka.internal.stream;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcherTest.java
@@ -242,6 +242,31 @@ public final class HeaderValueMessageDispatcherTest
         dispatcher.remove(asOctets("header1"), headers2, 1, child1);
     }
 
+    @Test
+    public void shouldToString()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        ListFW<KafkaHeaderFW> headers1 =
+                headersRW.wrap(headers1Buffer, 0, headers1Buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .build();
+        dispatcher.add(asOctets("value1"), headers1, 1, child1);
+        ListFW<KafkaHeaderFW> headers2 =
+                headersRW.wrap(headers2Buffer, 0, headers2Buffer.capacity())
+                .item(b -> b.key("value1").value(asOctets("value1")))
+                .item(b -> b.key("header2").value(asOctets("value2")))
+                .build();
+        dispatcher.add(asOctets("value1"), headers2, 1, child2);
+        String result = dispatcher.toString();
+        assertTrue(result.contains(child1.toString()));
+        assertTrue(result.contains(child2.toString()));
+        assertTrue(result.contains("header1"));
+        assertTrue(result.contains("header2"));
+        assertTrue(result.contains("value1"));
+        assertTrue(result.contains("value2"));
+    }
+
     private DirectBuffer asBuffer(String value)
     {
         byte[] bytes = value.getBytes(UTF_8);

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcherTest.java
@@ -1,0 +1,274 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.Function;
+
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.jmock.Expectations;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Rule;
+import org.junit.Test;
+import org.reaktivity.nukleus.kafka.internal.types.ListFW;
+import org.reaktivity.nukleus.kafka.internal.types.OctetsFW;
+import org.reaktivity.nukleus.kafka.internal.types.stream.KafkaHeaderFW;
+
+public final class HeaderValueMessageDispatcherTest
+{
+    private final ListFW.Builder<KafkaHeaderFW.Builder, KafkaHeaderFW> headersRW =
+         new ListFW.Builder<KafkaHeaderFW.Builder, KafkaHeaderFW>(new KafkaHeaderFW.Builder(), new KafkaHeaderFW());
+    private final MutableDirectBuffer headers1Buffer = new UnsafeBuffer(new byte[1000]);
+    private final MutableDirectBuffer headers2Buffer = new UnsafeBuffer(new byte[1000]);
+
+    private HeaderValueMessageDispatcher dispatcher = new HeaderValueMessageDispatcher(asBuffer("header1"));
+
+    @Rule
+    public JUnitRuleMockery context = new JUnitRuleMockery();
+
+    @Test
+    public void shouldAddNewDispatchers()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        ListFW<KafkaHeaderFW> headers1 =
+                headersRW.wrap(headers1Buffer, 0, headers1Buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .build();
+        dispatcher.add(asOctets("header1"), headers1, 1, child1);
+        ListFW<KafkaHeaderFW> headers2 =
+                headersRW.wrap(headers2Buffer, 0, headers2Buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .item(b -> b.key("header2").value(asOctets("value2")))
+                .build();
+        dispatcher.add(asOctets("header1"), headers2, 1, child2);
+    }
+
+    @Test
+    public void shouldDispatchOneAndTwoMatchingHeaders()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        ListFW<KafkaHeaderFW> headers1 =
+                headersRW.wrap(headers1Buffer, 0, headers1Buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .build();
+        dispatcher.add(asOctets("value1"), headers1, 1, child1);
+        ListFW<KafkaHeaderFW> headers2 =
+                headersRW.wrap(headers2Buffer, 0, headers2Buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .item(b -> b.key("header2").value(asOctets("value2")))
+                .build();
+        dispatcher.add(asOctets("value1"), headers2, 1, child2);
+
+        @SuppressWarnings("unchecked")
+        Function<DirectBuffer, DirectBuffer> supplyHeader = context.mock(Function.class, "header");
+
+        context.checking(new Expectations()
+        {
+            {
+                oneOf(supplyHeader).apply(with(bufferMatching("header1")));
+                will(returnValue(asBuffer("value1")));
+                oneOf(supplyHeader).apply(with(bufferMatching("header2")));
+                will(returnValue(asBuffer("value2")));
+                oneOf(child1).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key")),
+                        with(supplyHeader), with((DirectBuffer) null));
+                will(returnValue(1));
+                oneOf(child2).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key")),
+                        with(supplyHeader), with((DirectBuffer) null));
+                will(returnValue(1));
+            }
+        });
+        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, asBuffer("key"), supplyHeader, null));
+    }
+
+    @Test
+    public void shouldDispatchOnlyOneWithHeader2Absent()
+    {
+
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        ListFW<KafkaHeaderFW> headers1 =
+                headersRW.wrap(headers1Buffer, 0, headers1Buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .build();
+        dispatcher.add(asOctets("value1"), headers1, 1, child1);
+        ListFW<KafkaHeaderFW> headers2 =
+                headersRW.wrap(headers2Buffer, 0, headers2Buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .item(b -> b.key("header2").value(asOctets("value2")))
+                .build();
+        dispatcher.add(asOctets("value1"), headers2, 1, child2);
+
+        @SuppressWarnings("unchecked")
+        Function<DirectBuffer, DirectBuffer> supplyHeader = context.mock(Function.class, "header");
+
+        context.checking(new Expectations()
+        {
+            {
+                oneOf(supplyHeader).apply(with(bufferMatching("header1")));
+                will(returnValue(asBuffer("value1")));
+                oneOf(supplyHeader).apply(with(bufferMatching("header2")));
+                will(returnValue(null));
+                oneOf(child1).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key")),
+                        with(supplyHeader), with((DirectBuffer) null));
+                will(returnValue(1));
+            }
+        });
+        assertEquals(1, dispatcher.dispatch(1, 10L, 12L, asBuffer("key"), supplyHeader, null));
+    }
+
+    @Test
+    public void shouldNotDispatchWhenNoMatchingHeaders()
+    {
+
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        ListFW<KafkaHeaderFW> headers1 =
+                headersRW.wrap(headers1Buffer, 0, headers1Buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .build();
+        dispatcher.add(asOctets("value1"), headers1, 1, child1);
+        ListFW<KafkaHeaderFW> headers2 =
+                headersRW.wrap(headers2Buffer, 0, headers2Buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .item(b -> b.key("header2").value(asOctets("value2")))
+                .build();
+        dispatcher.add(asOctets("value1"), headers2, 1, child2);
+
+        @SuppressWarnings("unchecked")
+        Function<DirectBuffer, DirectBuffer> supplyHeader = context.mock(Function.class, "header");
+
+        context.checking(new Expectations()
+        {
+            {
+                oneOf(supplyHeader).apply(with(bufferMatching("header1")));
+                will(returnValue(asBuffer("no match")));
+            }
+        });
+        assertEquals(0, dispatcher.dispatch(1, 10L, 12L, asBuffer("key"), supplyHeader, null));
+    }
+
+    @Test
+    public void shouldFlush()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        ListFW<KafkaHeaderFW> headers1 =
+                headersRW.wrap(headers1Buffer, 0, headers1Buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .build();
+        dispatcher.add(asOctets("header1"), headers1, 1, child1);
+        ListFW<KafkaHeaderFW> headers2 =
+                headersRW.wrap(headers2Buffer, 0, headers2Buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .item(b -> b.key("header2").value(asOctets("value2")))
+                .build();
+        dispatcher.add(asOctets("header1"), headers2, 1, child2);
+        context.checking(new Expectations()
+        {
+            {
+                oneOf(child1).flush(1, 10L, 12L);
+                oneOf(child2).flush(1, 10L, 12L);
+            }
+        });
+        dispatcher.flush(1, 10L, 12L);
+    }
+
+    @Test
+    public void shouldRemoveDispatcherWhenPresent()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        int limit = headersRW.wrap(headers1Buffer, 0, headers1Buffer.capacity())
+                             .item(b -> b.key("header1").value(asOctets("value1")))
+                             .build()
+                             .limit();
+        ListFW<KafkaHeaderFW> headers1 = new ListFW<>(new KafkaHeaderFW())
+                .wrap(headers1Buffer,  0, limit);
+        limit = headersRW.wrap(headers2Buffer, 0, headers2Buffer.capacity())
+                         .item(b -> b.key("header1").value(asOctets("value1")))
+                         .item(b -> b.key("header2").value(asOctets("value2")))
+                         .build()
+                         .limit();
+        ListFW<KafkaHeaderFW> headers2 = new ListFW<>(new KafkaHeaderFW())
+                .wrap(headers2Buffer,  0, limit);
+
+        dispatcher.add(asOctets("value1"), headers1, 1, child1);
+        dispatcher.add(asOctets("value1"), headers2, 1, child2);
+
+        assertTrue(dispatcher.remove(asOctets("value1"), headers2, 1, child2));
+        assertFalse(dispatcher.isEmpty());
+
+        assertTrue(dispatcher.remove(asOctets("value1"), headers1, 1, child1));
+        assertTrue(dispatcher.isEmpty());
+    }
+
+    @Test
+    public void shouldNotRemoveDispatcherWhenNotPresent()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        ListFW<KafkaHeaderFW> headers2 =
+                headersRW.wrap(headers2Buffer, 0, headers2Buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .item(b -> b.key("header2").value(asOctets("value2")))
+                .build();
+        dispatcher.remove(asOctets("header1"), headers2, 1, child1);
+    }
+
+    private DirectBuffer asBuffer(String value)
+    {
+        byte[] bytes = value.getBytes(UTF_8);
+        return new UnsafeBuffer(bytes);
+    }
+
+    private OctetsFW asOctets(String value)
+    {
+        DirectBuffer buffer = asBuffer(value);
+        return new OctetsFW().wrap(buffer, 0, buffer.capacity());
+    }
+
+    private Matcher<DirectBuffer> bufferMatching(final String string)
+    {
+        return new BaseMatcher<DirectBuffer>()
+        {
+
+            @Override
+            public boolean matches(Object item)
+            {
+                return item instanceof UnsafeBuffer &&
+                        ((UnsafeBuffer)item).equals(new UnsafeBuffer(string.getBytes(UTF_8)));
+            }
+
+            @Override
+            public void describeTo(Description description)
+            {
+                description.appendText(string);
+            }
+
+        };
+    }
+
+}

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcherTest.java
@@ -86,6 +86,8 @@ public final class HeaderValueMessageDispatcherTest
         @SuppressWarnings("unchecked")
         Function<DirectBuffer, DirectBuffer> supplyHeader = context.mock(Function.class, "header");
 
+        final long timestamp = System.currentTimeMillis() - 123;
+
         context.checking(new Expectations()
         {
             {
@@ -94,14 +96,14 @@ public final class HeaderValueMessageDispatcherTest
                 oneOf(supplyHeader).apply(with(bufferMatching("header2")));
                 will(returnValue(asBuffer("value2")));
                 oneOf(child1).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key")),
-                        with(supplyHeader), with((DirectBuffer) null));
+                        with(supplyHeader), with(timestamp), with((DirectBuffer) null));
                 will(returnValue(1));
                 oneOf(child2).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key")),
-                        with(supplyHeader), with((DirectBuffer) null));
+                        with(supplyHeader), with(timestamp), with((DirectBuffer) null));
                 will(returnValue(1));
             }
         });
-        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, asBuffer("key"), supplyHeader, null));
+        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, asBuffer("key"), supplyHeader, timestamp, null));
     }
 
     @Test
@@ -125,6 +127,8 @@ public final class HeaderValueMessageDispatcherTest
         @SuppressWarnings("unchecked")
         Function<DirectBuffer, DirectBuffer> supplyHeader = context.mock(Function.class, "header");
 
+        final long timestamp = System.currentTimeMillis() - 123;
+
         context.checking(new Expectations()
         {
             {
@@ -133,11 +137,11 @@ public final class HeaderValueMessageDispatcherTest
                 oneOf(supplyHeader).apply(with(bufferMatching("header2")));
                 will(returnValue(null));
                 oneOf(child1).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key")),
-                        with(supplyHeader), with((DirectBuffer) null));
+                        with(supplyHeader), with(timestamp), with((DirectBuffer) null));
                 will(returnValue(1));
             }
         });
-        assertEquals(1, dispatcher.dispatch(1, 10L, 12L, asBuffer("key"), supplyHeader, null));
+        assertEquals(1, dispatcher.dispatch(1, 10L, 12L, asBuffer("key"), supplyHeader, timestamp, null));
     }
 
     @Test
@@ -168,7 +172,7 @@ public final class HeaderValueMessageDispatcherTest
                 will(returnValue(asBuffer("no match")));
             }
         });
-        assertEquals(0, dispatcher.dispatch(1, 10L, 12L, asBuffer("key"), supplyHeader, null));
+        assertEquals(0, dispatcher.dispatch(1, 10L, 12L, asBuffer("key"), supplyHeader, 123L, null));
     }
 
     @Test

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcherTest.java
@@ -85,22 +85,24 @@ public final class KeyMessageDispatcherTest
         @SuppressWarnings("unchecked")
         Function<DirectBuffer, DirectBuffer> header = context.mock(Function.class, "header");
 
+        final long timestamp = System.currentTimeMillis() - 123;
+
         context.checking(new Expectations()
         {
             {
                 oneOf(child1).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key1")),
-                        with(header), with((DirectBuffer) null));
+                        with(header), with(timestamp), with((DirectBuffer) null));
                 will(returnValue(1));
                 oneOf(child2).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key1")),
-                        with(header), with((DirectBuffer) null));
+                        with(header), with(timestamp), with((DirectBuffer) null));
                 will(returnValue(1));
                 oneOf(child3).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key2")),
-                        with(header), with((DirectBuffer) null));
+                        with(header), with(timestamp), with((DirectBuffer) null));
                 will(returnValue(1));
             }
         });
-        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, asBuffer("key1"), header, null));
-        assertEquals(1, dispatcher.dispatch(1, 10L, 12L, asBuffer("key2"), header, null));
+        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, asBuffer("key1"), header, timestamp, null));
+        assertEquals(1, dispatcher.dispatch(1, 10L, 12L, asBuffer("key2"), header, timestamp, null));
     }
 
     @Test
@@ -114,12 +116,14 @@ public final class KeyMessageDispatcherTest
         @SuppressWarnings("unchecked")
         Function<DirectBuffer, DirectBuffer> header = context.mock(Function.class, "header");
 
+        final long timestamp = System.currentTimeMillis() - 123;
+
         context.checking(new Expectations()
         {
             {
             }
         });
-        assertEquals(0, dispatcher.dispatch(1, 10L, 12L, asBuffer("key2"), header, null));
+        assertEquals(0, dispatcher.dispatch(1, 10L, 12L, asBuffer("key2"), header, timestamp, null));
     }
 
     @Test

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcherTest.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.Function;
+
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.jmock.Expectations;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Rule;
+import org.junit.Test;
+import org.reaktivity.nukleus.kafka.internal.types.ListFW;
+import org.reaktivity.nukleus.kafka.internal.types.OctetsFW;
+import org.reaktivity.nukleus.kafka.internal.types.stream.KafkaHeaderFW;
+
+public final class KeyMessageDispatcherTest
+{
+    private KeyMessageDispatcher dispatcher = new KeyMessageDispatcher();
+
+    private final ListFW.Builder<KafkaHeaderFW.Builder, KafkaHeaderFW> headersRW =
+            new ListFW.Builder<KafkaHeaderFW.Builder, KafkaHeaderFW>(new KafkaHeaderFW.Builder(), new KafkaHeaderFW());
+       private final MutableDirectBuffer headersBuffer = new UnsafeBuffer(new byte[1000]);
+
+    @Rule
+    public JUnitRuleMockery context = new JUnitRuleMockery();
+
+    @Test
+    public void shouldAddDispatcherWithEmptHeaders()
+    {
+        ListFW<KafkaHeaderFW> headers = headersRW.wrap(headersBuffer, 0, headersBuffer.capacity())
+                                                 .build();
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        dispatcher.add(asOctets("key1"), headers, child1);
+    }
+
+    @Test
+    public void shouldAddDispatcherWithNullHeaders()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        dispatcher.add(asOctets("key1"), null, child1);
+    }
+
+    @Test
+    public void shouldAddMultipleDispatchersWithSameKey()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        dispatcher.add(asOctets("key1"), null, child1);
+        dispatcher.add(asOctets("key1"), null, child2);
+    }
+
+    @Test
+    public void shouldDispatchWithMatchingKey()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        MessageDispatcher child3 = context.mock(MessageDispatcher.class, "child3");
+        dispatcher.add(asOctets("key1"), null, child1);
+        dispatcher.add(asOctets("key1"), null, child2);
+        dispatcher.add(asOctets("key2"), null, child3);
+
+        @SuppressWarnings("unchecked")
+        Function<DirectBuffer, DirectBuffer> header = context.mock(Function.class, "header");
+
+        context.checking(new Expectations()
+        {
+            {
+                oneOf(child1).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key1")),
+                        with(header), with((DirectBuffer) null));
+                will(returnValue(1));
+                oneOf(child2).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key1")),
+                        with(header), with((DirectBuffer) null));
+                will(returnValue(1));
+                oneOf(child3).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key2")),
+                        with(header), with((DirectBuffer) null));
+                will(returnValue(1));
+            }
+        });
+        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, asBuffer("key1"), header, null));
+        assertEquals(1, dispatcher.dispatch(1, 10L, 12L, asBuffer("key2"), header, null));
+    }
+
+    @Test
+    public void shouldNotDispatchNonMatchingKey()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        dispatcher.add(asOctets("key1"), null, child1);
+        dispatcher.add(asOctets("key1"), null, child2);
+
+        @SuppressWarnings("unchecked")
+        Function<DirectBuffer, DirectBuffer> header = context.mock(Function.class, "header");
+
+        context.checking(new Expectations()
+        {
+            {
+            }
+        });
+        assertEquals(0, dispatcher.dispatch(1, 10L, 12L, asBuffer("key2"), header, null));
+    }
+
+    @Test
+    public void shouldFlush()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        dispatcher.add(asOctets("key1"), null, child1);
+        dispatcher.add(asOctets("key1"), null, child2);
+        context.checking(new Expectations()
+        {
+            {
+                oneOf(child1).flush(1, 10L, 12L);
+                oneOf(child2).flush(1, 10L, 12L);
+            }
+        });
+        dispatcher.flush(1, 10L, 12L);
+    }
+
+    @Test
+    public void shouldRemoveDispatchers()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        dispatcher.add(asOctets("key1"), null, child1);
+        dispatcher.add(asOctets("key1"), null, child2);
+        assertTrue(dispatcher.remove(asOctets("key1"), null, child1));
+        assertTrue(dispatcher.remove(asOctets("key1"), null, child2));
+        assertTrue(dispatcher.isEmpty());
+    }
+
+    @Test
+    public void shouldNotRemoveDispatcherWhenNotPresent()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+
+        assertFalse(dispatcher.remove(asOctets("key1"), null, child1));
+
+        dispatcher.add(asOctets("key1"), null, child1);
+        assertFalse(dispatcher.remove(asOctets("key1"), null, child2));
+    }
+
+    private DirectBuffer asBuffer(String value)
+    {
+        byte[] bytes = value.getBytes(UTF_8);
+        return new UnsafeBuffer(bytes);
+    }
+
+    private OctetsFW asOctets(String value)
+    {
+        DirectBuffer buffer = asBuffer(value);
+        return new OctetsFW().wrap(buffer, 0, buffer.capacity());
+    }
+
+    private Matcher<DirectBuffer> bufferMatching(final String string)
+    {
+        return new BaseMatcher<DirectBuffer>()
+        {
+
+            @Override
+            public boolean matches(Object item)
+            {
+                return item instanceof UnsafeBuffer &&
+                        ((UnsafeBuffer)item).equals(new UnsafeBuffer(string.getBytes(UTF_8)));
+            }
+
+            @Override
+            public void describeTo(Description description)
+            {
+                description.appendText(string);
+            }
+
+        };
+    }
+
+}

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MetadataIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MetadataIT.java
@@ -13,37 +13,30 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package org.reaktivity.nukleus.kafka.internal.streams;
+package org.reaktivity.nukleus.kafka.internal.stream;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.isA;
 import static org.junit.rules.RuleChain.outerRule;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import org.kaazing.k3po.junit.annotation.ScriptProperty;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.reaktivity.reaktor.internal.ReaktorConfiguration;
 import org.reaktivity.reaktor.test.ReaktorRule;
 
-public class FetchLimitsIT
+public class MetadataIT
 {
     private final K3poRule k3po = new K3poRule()
             .addScriptRoot("route", "org/reaktivity/specification/nukleus/kafka/control/route.ext")
-            .addScriptRoot("routeAnyTopic", "org/reaktivity/specification/nukleus/kafka/control/route")
-            .addScriptRoot("server", "org/reaktivity/specification/kafka/fetch.v5")
             .addScriptRoot("metadata", "org/reaktivity/specification/kafka/metadata.v5")
+            .addScriptRoot("server", "org/reaktivity/specification/kafka/fetch.v5")
             .addScriptRoot("client", "org/reaktivity/specification/nukleus/kafka/streams/fetch");
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+    private final TestRule timeout = new DisableOnDebug(new Timeout(15, SECONDS));
 
     private final ReaktorRule reaktor = new ReaktorRule()
         .nukleus("kafka"::equals)
@@ -51,22 +44,18 @@ public class FetchLimitsIT
         .commandBufferCapacity(1024)
         .responseBufferCapacity(1024)
         .counterValuesBufferCapacity(1024)
-        .clean()
-        .configure(ReaktorConfiguration.BUFFER_SLOT_CAPACITY_PROPERTY, 256);
+        .clean();
 
     @Rule
     public final TestRule chain = outerRule(reaktor).around(k3po).around(timeout);
 
-    @Rule
-    public ExpectedException expected = ExpectedException.none();
-
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/zero.offset.messages.multiple.partitions.max.bytes.256/client",
-        "${server}/zero.offset.messages.multiple.partitions.max.bytes.256/server" })
+        "${client}/zero.offset/client",
+        "${metadata}/one.topic.leader.not.available.and.retry/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldReceiveMessagesFromMultiplePartitionsWhenResponseSizeEqualsSlotSize() throws Exception
+    public void shouldRetryWhenLeaderNotAvailable() throws Exception
     {
         k3po.finish();
     }
@@ -75,14 +64,55 @@ public class FetchLimitsIT
     @Specification({
         "${route}/client/controller",
         "${client}/zero.offset/client",
-        "${server}/zero.offset.message.response.exceeds.requested.256.bytes/server" })
+        "${metadata}/broker.connection.reset.and.retry/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldHandleFetchResponseExceedingRequestedMaxFetchBytes() throws Exception
+    public void shouldRetryWhenBrokerNotAvailable() throws Exception
     {
-        expected.expect(anyOf(isA(IllegalStateException.class),
-                hasProperty("failures", hasItem(isA(IllegalStateException.class)))));
-        k3po.start();
-        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/zero.offset/client",
+        "${metadata}/one.topic.multiple.nodes/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldHandleMetadataResponseOneTopicOnMultipleNodes() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/zero.offset/client",
+        "${metadata}/one.topic.multiple.nodes.and.replicas/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldHandleMetadataResponseOneTopicMultipleNodesAndReplicas() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/zero.offset/client",
+        "${metadata}/one.topic.multiple.partitions/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldHandleMetadataResponseOneTopicMultiplePartitionsSingleNode() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/zero.offset/client",
+        "${metadata}/one.topic.single.partition/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldHandleMetadataResponseOneTopicSinglePartition() throws Exception
+    {
+        k3po.finish();
+    }
+
 }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcherTest.java
@@ -1,0 +1,258 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.Function;
+
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.jmock.Expectations;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Rule;
+import org.junit.Test;
+import org.reaktivity.nukleus.kafka.internal.types.ListFW;
+import org.reaktivity.nukleus.kafka.internal.types.OctetsFW;
+import org.reaktivity.nukleus.kafka.internal.types.stream.KafkaHeaderFW;
+
+public final class TopicMessageDispatcherTest
+{
+    private TopicMessageDispatcher dispatcher = new TopicMessageDispatcher();
+
+    private final ListFW.Builder<KafkaHeaderFW.Builder, KafkaHeaderFW> headersRW =
+            new ListFW.Builder<KafkaHeaderFW.Builder, KafkaHeaderFW>(new KafkaHeaderFW.Builder(), new KafkaHeaderFW());
+       private final MutableDirectBuffer headersBuffer = new UnsafeBuffer(new byte[1000]);
+
+    @Rule
+    public JUnitRuleMockery context = new JUnitRuleMockery();
+
+    @Test
+    public void shouldAddDispatcherWithEmptyHeadersAndNullKey()
+    {
+        ListFW<KafkaHeaderFW> headers = headersRW.wrap(headersBuffer, 0, headersBuffer.capacity())
+                                                 .build();
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        dispatcher.add(null, headers, child1);
+    }
+
+    @Test
+    public void shouldAddDispatcherWithNullHeadersAndNullKey()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        dispatcher.add(null, null, child1);
+    }
+
+    @Test
+    public void shouldAddMultipleDispatchersWithSameKey()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        dispatcher.add(asOctets("key1"), null, child1);
+        dispatcher.add(asOctets("key1"), null, child2);
+    }
+
+    @Test
+    public void shouldDispatchWithoutKey()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        dispatcher.add(null, null, child1);
+        dispatcher.add(null, null, child2);
+
+        @SuppressWarnings("unchecked")
+        Function<DirectBuffer, DirectBuffer> header = context.mock(Function.class, "header");
+
+        context.checking(new Expectations()
+        {
+            {
+                oneOf(child1).dispatch(with(1), with(10L), with(12L), with((DirectBuffer) null),
+                        with(header), with((DirectBuffer) null));
+                will(returnValue(1));
+                oneOf(child2).dispatch(with(1), with(10L), with(12L), with((DirectBuffer) null),
+                        with(header), with((DirectBuffer) null));
+                will(returnValue(1));
+            }
+        });
+        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, null, header, null));
+    }
+
+
+    @Test
+    public void shouldDispatchWithMatchingKey()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        MessageDispatcher child3 = context.mock(MessageDispatcher.class, "child3");
+        dispatcher.add(asOctets("key1"), null, child1);
+        dispatcher.add(asOctets("key1"), null, child2);
+        dispatcher.add(asOctets("key2"), null, child3);
+
+        @SuppressWarnings("unchecked")
+        Function<DirectBuffer, DirectBuffer> header = context.mock(Function.class, "header");
+
+        context.checking(new Expectations()
+        {
+            {
+                oneOf(child1).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key1")),
+                        with(header), with((DirectBuffer) null));
+                will(returnValue(1));
+                oneOf(child2).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key1")),
+                        with(header), with((DirectBuffer) null));
+                will(returnValue(1));
+                oneOf(child3).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key2")),
+                        with(header), with((DirectBuffer) null));
+                will(returnValue(1));
+            }
+        });
+        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, asBuffer("key1"), header, null));
+        assertEquals(1, dispatcher.dispatch(1, 10L, 12L, asBuffer("key2"), header, null));
+    }
+
+    @Test
+    public void shouldNotDispatchNonMatchingKey()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        dispatcher.add(asOctets("key1"), null, child1);
+        dispatcher.add(asOctets("key1"), null, child2);
+
+        @SuppressWarnings("unchecked")
+        Function<DirectBuffer, DirectBuffer> header = context.mock(Function.class, "header");
+
+        context.checking(new Expectations()
+        {
+            {
+            }
+        });
+        assertEquals(0, dispatcher.dispatch(1, 10L, 12L, asBuffer("key2"), header, null));
+    }
+
+    @Test
+    public void shouldFlush()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        dispatcher.add(asOctets("key1"), null, child1);
+        dispatcher.add(asOctets("key1"), null, child2);
+        context.checking(new Expectations()
+        {
+            {
+                oneOf(child1).flush(1, 10L, 12L);
+                oneOf(child2).flush(1, 10L, 12L);
+            }
+        });
+        dispatcher.flush(1, 10L, 12L);
+    }
+
+    @Test
+    public void shouldRemoveKeyDispatchers()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        ListFW<KafkaHeaderFW> emptyHeaders = headersRW.wrap(headersBuffer, 0, headersBuffer.capacity())
+                .build();
+        dispatcher.add(asOctets("key1"), null, child1);
+        dispatcher.add(asOctets("key1"), emptyHeaders, child2);
+        assertTrue(dispatcher.remove(asOctets("key1"), null, child1));
+        assertTrue(dispatcher.remove(asOctets("key1"), emptyHeaders, child2));
+        assertTrue(dispatcher.isEmpty());
+    }
+
+    @Test
+    public void shouldRemoveHeadersDispatchers()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        ListFW<KafkaHeaderFW> headers =
+                headersRW.wrap(headersBuffer, 0, headersBuffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .build();
+        dispatcher.add(null, headers, child1);
+        dispatcher.add(asOctets("key1"), headers, child2);
+        assertTrue(dispatcher.remove(null, headers, child1));
+        assertTrue(dispatcher.remove(asOctets("key1"), headers, child2));
+        assertTrue(dispatcher.isEmpty());
+    }
+
+    @Test
+    public void shouldRemoveUnconditionalDispatchers()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        ListFW<KafkaHeaderFW> emptyHeaders = headersRW
+                .wrap(headersBuffer, 0, headersBuffer.capacity())
+                .build();
+        dispatcher.add(null, emptyHeaders, child1);
+        dispatcher.add(null, null, child2);
+        assertTrue(dispatcher.remove(null, emptyHeaders, child1));
+        assertTrue(dispatcher.remove(null, null, child2));
+        assertTrue(dispatcher.isEmpty());
+    }
+
+    @Test
+    public void shouldNotRemoveDispatcherWhenNotPresent()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+
+        assertFalse(dispatcher.remove(asOctets("key1"), null, child1));
+
+        dispatcher.add(asOctets("key1"), null, child1);
+        assertFalse(dispatcher.remove(asOctets("key1"), null, child2));
+    }
+
+    private DirectBuffer asBuffer(String value)
+    {
+        byte[] bytes = value.getBytes(UTF_8);
+        return new UnsafeBuffer(bytes);
+    }
+
+    private OctetsFW asOctets(String value)
+    {
+        DirectBuffer buffer = asBuffer(value);
+        return new OctetsFW().wrap(buffer, 0, buffer.capacity());
+    }
+
+    private Matcher<DirectBuffer> bufferMatching(final String string)
+    {
+        return new BaseMatcher<DirectBuffer>()
+        {
+
+            @Override
+            public boolean matches(Object item)
+            {
+                return item instanceof UnsafeBuffer &&
+                        ((UnsafeBuffer)item).equals(new UnsafeBuffer(string.getBytes(UTF_8)));
+            }
+
+            @Override
+            public void describeTo(Description description)
+            {
+                description.appendText(string);
+            }
+
+        };
+    }
+
+}

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcherTest.java
@@ -83,18 +83,20 @@ public final class TopicMessageDispatcherTest
         @SuppressWarnings("unchecked")
         Function<DirectBuffer, DirectBuffer> header = context.mock(Function.class, "header");
 
+        final long timestamp = System.currentTimeMillis() - 123;
+
         context.checking(new Expectations()
         {
             {
                 oneOf(child1).dispatch(with(1), with(10L), with(12L), with((DirectBuffer) null),
-                        with(header), with((DirectBuffer) null));
+                        with(header), with(timestamp), with((DirectBuffer) null));
                 will(returnValue(1));
                 oneOf(child2).dispatch(with(1), with(10L), with(12L), with((DirectBuffer) null),
-                        with(header), with((DirectBuffer) null));
+                        with(header), with(timestamp), with((DirectBuffer) null));
                 will(returnValue(1));
             }
         });
-        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, null, header, null));
+        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, null, header, timestamp, null));
     }
 
 
@@ -111,22 +113,25 @@ public final class TopicMessageDispatcherTest
         @SuppressWarnings("unchecked")
         Function<DirectBuffer, DirectBuffer> header = context.mock(Function.class, "header");
 
+        final long timestamp1 = System.currentTimeMillis() - 123;
+        final long timestamp2 = System.currentTimeMillis() - 123;
+
         context.checking(new Expectations()
         {
             {
                 oneOf(child1).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key1")),
-                        with(header), with((DirectBuffer) null));
+                        with(header), with(timestamp1), with((DirectBuffer) null));
                 will(returnValue(1));
                 oneOf(child2).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key1")),
-                        with(header), with((DirectBuffer) null));
+                        with(header), with(timestamp1), with((DirectBuffer) null));
                 will(returnValue(1));
                 oneOf(child3).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key2")),
-                        with(header), with((DirectBuffer) null));
+                        with(header), with(timestamp2), with((DirectBuffer) null));
                 will(returnValue(1));
             }
         });
-        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, asBuffer("key1"), header, null));
-        assertEquals(1, dispatcher.dispatch(1, 10L, 12L, asBuffer("key2"), header, null));
+        assertEquals(2, dispatcher.dispatch(1, 10L, 12L, asBuffer("key1"), header, timestamp1, null));
+        assertEquals(1, dispatcher.dispatch(1, 10L, 12L, asBuffer("key2"), header, timestamp2, null));
     }
 
     @Test
@@ -140,12 +145,14 @@ public final class TopicMessageDispatcherTest
         @SuppressWarnings("unchecked")
         Function<DirectBuffer, DirectBuffer> header = context.mock(Function.class, "header");
 
+        final long timestamp = System.currentTimeMillis() - 123;
+
         context.checking(new Expectations()
         {
             {
             }
         });
-        assertEquals(0, dispatcher.dispatch(1, 10L, 12L, asBuffer("key2"), header, null));
+        assertEquals(0, dispatcher.dispatch(1, 10L, 12L, asBuffer("key2"), header, timestamp, null));
     }
 
     @Test


### PR DESCRIPTION
Enhancements to message dispatching to avoid decoding each record set in the fetch response for every consumer, and use a hierarchy of consumers so filter conditions need only be applied once.