### PR TITLE
Fixed a bug in ClientAcceptStream.flush: handle case where no messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.28</nukleus.kafka.spec.version>
     <reaktor.version>0.38</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.27</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.38</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -485,10 +485,15 @@ public final class ClientStreamFactory implements StreamFactory
         {
             flushPreviousMessage(partition, lastOffset);
             long endOffset = progressEndOffset;
-            if (requestOffset <= progressStartOffset
+            if (progressStartOffset == UNSET)
+            {
+                progressStartOffset = requestOffset;
+                endOffset = lastOffset;
+            }
+            else if (requestOffset <= progressStartOffset
                     && writeableBytesMinimum == 0)
             {
-                // We didn't skip any messages, advance to highest offset
+                // We didn't skip any messages due to lack of window, advance to highest offset
                 endOffset = lastOffset;
             }
             if (endOffset > progressStartOffset)

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -57,7 +57,7 @@ import org.reaktivity.nukleus.stream.StreamFactory;
 
 public final class ClientStreamFactory implements StreamFactory
 {
-    private static final long UNSET = -1;
+    static final long UNSET = -1;
 
     static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
@@ -512,6 +512,7 @@ public final class ClientStreamFactory implements StreamFactory
         {
             if (messagePending)
             {
+                this.fetchOffsets.put(partition, messageOffset);
                 doKafkaData(applicationReply, applicationReplyId, applicationReplyPadding,
                             compacted ? pendingMessageKey : null,
                             pendingMessageTimestamp, pendingMessageValue, fetchOffsets);

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1392,6 +1392,7 @@ final class NetworkConnectionPool
                 final int recordSetLimit = networkOffset + recordSet.recordBatchSize();
                 if (recordSetLimit <= maxLimit)
                 {
+                    long nextFetchAt = requestedOffset;
                     loop:
                     while (networkOffset < recordSetLimit - RecordBatchFW.FIELD_OFFSET_RECORD_COUNT - BitUtil.SIZE_OF_INT)
                     {
@@ -1407,7 +1408,7 @@ final class NetworkConnectionPool
 
                         final long firstOffset = recordBatch.firstOffset();
                         final long firstTimestamp = recordBatch.firstTimestamp();
-                        long nextFetchAt = firstOffset;
+                        nextFetchAt = firstOffset;
                         while (networkOffset < recordBatchLimit - 7 /* minimum RecordFW size */)
                         {
                             final RecordFW record = recordRO.wrap(buffer, networkOffset, recordBatchLimit);
@@ -1453,8 +1454,8 @@ final class NetworkConnectionPool
                             dispatcher.dispatch(partitionId, requestedOffset, nextFetchAt,
                                          key, headers::supplyHeader, timestamp, value);
                         }
-                        dispatcher.flush(partitionId, requestedOffset, nextFetchAt);
                     }
+                    dispatcher.flush(partitionId, requestedOffset, nextFetchAt);
                 }
             }
         }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -191,6 +191,18 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/fetch.key.zero.offset.no.messages/client",
+        "${server}/fetch.key.zero.offset.no.matches/server"})
+    @ScriptProperty({"networkAccept \"nukleus://target/streams/kafka\"",
+                     "applicationConnectWindow 15"})
+    public void shouldReceiveNoMessagesMatchingFetchKey() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/fetch.key.zero.offset.three.messages/client",
         "${server}/fetch.key.three.matches.flow.controlled/server"})
     @ScriptProperty({"networkAccept \"nukleus://target/streams/kafka\"",

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -168,6 +168,17 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/fetch.key.and.no.key.messages/client",
+        "${server}/fetch.key.and.no.key.multiple.partitions/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveMessageOnSubscribesWithAndWithoutKeyFromMultiplePartitions() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/fetch.key.default.partioner.picks.partition.one/client",
         "${server}/fetch.key.default.partioner.picks.partition.one/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -191,10 +191,31 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/fetch.key.zero.offset.message/client",
+        "${server}/fetch.key.multiple.record.batches.first.matches/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveMessageMatchingFetchKeyWithLastOffsetWithMultipleRecordBatches() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/fetch.key.zero.offset.no.messages/client",
-        "${server}/fetch.key.zero.offset.no.matches/server"})
-    @ScriptProperty({"networkAccept \"nukleus://target/streams/kafka\"",
-                     "applicationConnectWindow 15"})
+        "${server}/fetch.key.multiple.record.batches.no.matches/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveNoMessagesMatchingFetchKeyWithMultipleRecordBatches() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/fetch.key.zero.offset.no.messages/client",
+        "${server}/fetch.key.no.matches/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveNoMessagesMatchingFetchKey() throws Exception
     {
         k3po.finish();


### PR DESCRIPTION
were dispatched because none matched the request fetch key and/or headers. This was causing an AssertionError (or NPE) when a user subscribed with a fetch key or header criterion.

Also optimized message dispatch and flush by flushing only at the end of a record set instead of at the end of each record batch.

Also fixes a long-standing issue with parallel subscribes with different fetch keys and/or headers by passing copies of fetchKey and headers into the attach method to avoid memory being corrupted before attach is completed.

Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/23
