### PR TITLE
Added a test for case where unsubscribe was causing assert error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.28</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.38</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.29</nukleus.kafka.spec.version>
     <reaktor.version>0.38</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -179,6 +179,20 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/fetch.key.and.no.key.unsubscribe/client",
+        "${server}/fetch.key.and.no.key.multiple.partitions.unsubscribe/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldNotGiveAssertionErrorWhenUnsubscribeLeavingConsumerOnAnotherPartition() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("CLIENT_TWO_HAS_WRITTEN_RESET");
+        k3po.notifyBarrier("CLIENT_TWO_UNSUBSCRIBED");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/fetch.key.default.partioner.picks.partition.one/client",
         "${server}/fetch.key.default.partioner.picks.partition.one/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")


### PR DESCRIPTION
in getRequestedOffset (now renamed to getRequiredOffset) in the case because a fetch response comes in later and there a no longer consumers on that partition but there still are on others.

Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/24