### PR TITLE
Fixes to handle record batch with deleted records at end and a race between subscribe and describe config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.30</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.39</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.31</nukleus.kafka.spec.version>
     <reaktor.version>0.39</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.31</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.32</nukleus.kafka.spec.version>
     <reaktor.version>0.39</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -458,7 +458,7 @@ public final class ClientStreamFactory implements StreamFactory
             flushPreviousMessage(partition, messageOffset - 1);
 
             if (requestOffset <= progressStartOffset // avoid out of order delivery
-                && messageOffset > progressStartOffset
+                && messageOffset >= progressStartOffset
                 && writeableBytesMinimum == 0)
             {
                 final int payloadLength = value == null ? 0 : value.capacity();

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -458,7 +458,7 @@ public final class ClientStreamFactory implements StreamFactory
             flushPreviousMessage(partition, messageOffset - 1);
 
             if (requestOffset <= progressStartOffset // avoid out of order delivery
-                && messageOffset >= progressStartOffset
+                && messageOffset > progressStartOffset
                 && writeableBytesMinimum == 0)
             {
                 final int payloadLength = value == null ? 0 : value.capacity();

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1461,6 +1461,7 @@ final class NetworkConnectionPool
                             dispatcher.dispatch(partitionId, requestedOffset, nextFetchAt,
                                          key, headers::supplyHeader, timestamp, value);
                         }
+                        nextFetchAt = recordBatch.firstOffset() + recordBatch.lastOffsetDelta() + 1;
                     }
                     dispatcher.flush(partitionId, requestedOffset, nextFetchAt);
                 }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -404,6 +404,21 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/ktable.message.fanout/client",
+        "${server}/ktable.message.delayed.describe.response/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveKtableMessageWithMessageKeyAndLastOffset() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("DESCRIBE_REQUEST_RECEIVED");
+        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
+        k3po.notifyBarrier("DELIVER_DESCRIBE_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/ktable.messages/client",
         "${server}/ktable.messages/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
@@ -452,6 +467,17 @@ public class FetchIT
         "${server}/live.fetch.abort.and.reconnect/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReconnectOnAbortOnLiveFetchConnection() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/record.batch.ends.with.deleted.record/client",
+        "${server}/record.batch.ends.with.deleted.record/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldUseLastOffsetFromRecordBatch() throws Exception
     {
         k3po.finish();
     }


### PR DESCRIPTION
Requires: https://github.com/reaktivity/nukleus-kafka.spec/pull/26

 Contains the following fixes:
- Use the last offset delta reported on the record batch
- Do not prematurely deliver topic metadata to a consumer because the compacted state of the topic is known
-  Optimization: do not attempt to dispatch records whose offset is less than the requested offset