### PR TITLE
Clear out key offset cache entries for  tombstone (null value) messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.33</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.34</nukleus.kafka.spec.version>
     <reaktor.version>0.39</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -451,6 +451,17 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/ktable.historical.uses.cached.key.then.live.after.null.message/client",
+        "${server}/ktable.historical.uses.cached.key.then.live.after.null.message/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveKTableMessagesFromLiveStreamAfterCachedKeyRemovedByNullMessage() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/ktable.historical.uses.cached.key.then.zero.offset/client",
         "${server}/ktable.historical.uses.cached.key.then.zero.offset/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/28