### PR TITLE
Multiple subscribers fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.36</nukleus.kafka.spec.version>
     <reaktor.version>0.39</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.35</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.39</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/CachingKeyMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/CachingKeyMessageDispatcher.java
@@ -78,7 +78,7 @@ public class CachingKeyMessageDispatcher extends KeyMessageDispatcher
             // fast-forward to live stream after observing most recent cached offset for message key
             if (offset != null  && offset[0] == messageStartOffset)
             {
-                super.flush(partition, requestOffset, highestOffset);
+                flush(partition, requestOffset, highestOffset, key);
             }
         }
         return dispatched;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcher.java
@@ -73,6 +73,20 @@ public class KeyMessageDispatcher implements MessageDispatcher
         existing.add(headers, 0, dispatcher);
     }
 
+    protected void flush(
+            int partition,
+            long requestOffset,
+            long lastOffset,
+            DirectBuffer key)
+    {
+        buffer.wrap(key, 0, key.capacity());
+        MessageDispatcher dispatcher = dispatchersByKey.get(buffer);
+        if (dispatcher != null)
+        {
+            dispatcher.flush(partition, requestOffset, lastOffset);
+        }
+    }
+
     public boolean remove(OctetsFW key, ListFW<KafkaHeaderFW> headers, MessageDispatcher dispatcher)
     {
         boolean result = false;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1353,10 +1353,18 @@ final class NetworkConnectionPool
             candidate.id = partitionId;
             candidate.offset = fetchOffset;
             NetworkTopicPartition partition = partitions.floor(candidate);
-            if (partition == null || partition.id != candidate.id)
+            if (!candidate.equals(partition))
             {
-                NetworkTopicPartition ceiling = partitions.ceiling(candidate);
-                boolean needsHistorical = ceiling != null && ceiling.id == candidate.id;
+                boolean needsHistorical;
+                if (partition != null && partition.id == candidate.id)
+                {
+                    needsHistorical = true;
+                }
+                else
+                {
+                    NetworkTopicPartition ceiling = partitions.ceiling(candidate);
+                    needsHistorical = ceiling != null && ceiling.id == candidate.id;
+                }
                 needsHistoricalByPartition.set(candidate.id, needsHistorical);
                 partition = new NetworkTopicPartition();
                 partition.id = candidate.id;
@@ -1617,6 +1625,30 @@ final class NetworkConnectionPool
             }
 
             return comparison;
+        }
+
+        @Override
+        public boolean equals(
+            Object arg0)
+        {
+            boolean result = false;
+            if (this == arg0)
+            {
+                result = true;
+            }
+            else if (arg0 != null && arg0.getClass() == NetworkTopicPartition.class)
+            {
+                NetworkTopicPartition other = (NetworkTopicPartition) arg0;
+                result = this.id == other.id && this.offset == other.offset;
+            }
+            return result;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int offsetHash = id ^ (id >>> 32);
+            return 31 * id + offsetHash;
         }
 
         @Override

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -124,6 +124,23 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/distinct.offsets.message.fanout/client",
+        "${server}/distinct.offsets.message.fanout/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldHandleParallelSubscribesAtDistinctOffsets() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("CLIENT_ONE_CONNECTED");
+        k3po.awaitBarrier("SERVER_LIVE_REQUEST_RECEIVED");
+        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
+        k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
+        k3po.notifyBarrier("SERVER_DELIVER_LIVE_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/fanout.with.historical.message/client",
         "${server}/fanout.with.historical.message/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/30

Fixes are as follows:
- Fixed CachingKeyMessageDispatcher to call flush only on dispatchers with matchingthe message key key when updating historical to live stream (in dispatch method)
- Fixed NetworkTopic.attachToPartition to add distinct partitions for distinct offsets, to avoid an assertion error in progressHandler when two subscribers subscriber different offsets and are served from the same fetch stream.