### PR TITLE
Fixed NetworkConnectionPool to fix a decode buffer overflow issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.39</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.39</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.18</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.40</nukleus.kafka.spec.version>
     <reaktor.version>0.41</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -637,12 +637,7 @@ final class NetworkConnectionPool
                 {
                     if (networkSlotOffset == 0 && networkSlot != NO_SLOT)
                     {
-                        if (networkSlot == LOCAL_SLOT)
-                        {
-                            localDecodeCapacity = 0;
-                            localDecodeBuffer = null;
-                        }
-                        else
+                        if (networkSlot != LOCAL_SLOT)
                         {
                             bufferPool.release(networkSlot);
                         }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -586,7 +586,7 @@ final class NetworkConnectionPool
                         if (networkSlot == NO_SLOT)
                         {
                             final MutableDirectBuffer bufferSlot;
-                            if (responseSize > bufferPool.slotCapacity())
+                            if (responseSize + BitUtil.SIZE_OF_INT > bufferPool.slotCapacity())
                             {
                                 int requiredCapacity = response.sizeof() + response.size();
                                 int currentCapacity = localDecodeBuffer != null ? localDecodeBuffer.capacity() : 0;
@@ -641,7 +641,12 @@ final class NetworkConnectionPool
                 {
                     if (networkSlotOffset == 0 && networkSlot != NO_SLOT)
                     {
-                        if (networkSlot != LOCAL_SLOT)
+                        if (networkSlot == LOCAL_SLOT)
+                        {
+                            localDecodeCapacity = 0;
+                            localDecodeBuffer = null;
+                        }
+                        else
                         {
                             bufferPool.release(networkSlot);
                         }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -72,10 +72,10 @@ public class FetchLimitsIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/zero.offset/client",
-        "${server}/zero.offset.message.response.exceeds.requested.256.bytes/server" })
+        "${client}/zero.offset.messages.response.exceeds.requested.256.bytes/client",
+        "${server}/zero.offset.messages.response.exceeds.requested.256.bytes/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldHandleFetchResponseSizeExceedingSlotCapacity() throws Exception
+    public void shouldHandleFetchResponsesWithSizeExceedingSlotCapacity() throws Exception
     {
         k3po.start();
         k3po.notifyBarrier("WRITE_FETCH_RESPONSE");


### PR DESCRIPTION
Requires: https://github.com/reaktivity/nukleus-kafka.spec/pull/34

- ensure we always allocate a local decode buffer when needed
- free it immediately
- do not give out too much window for the next response
