### PR TITLE
Updated pom.xml to reinstate the ITs and pick up new spec version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.18</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.45</nukleus.kafka.spec.version>
     <reaktor.version>0.41</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <checkstyle.config.location>src/conf/checkstyle/configuration.xml</checkstyle.config.location>
     <checkstyle.suppressions.location>src/conf/checkstyle/suppressions.xml</checkstyle.suppressions.location>
-    <jacoco.coverage.ratio>0.06</jacoco.coverage.ratio>
-    <jacoco.missed.count>145</jacoco.missed.count>
+    <jacoco.coverage.ratio>0.49</jacoco.coverage.ratio>
+    <jacoco.missed.count>78</jacoco.missed.count>
 
     <junit.version>4.12</junit.version>
     <jmh.version>1.17.4</jmh.version>
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.18</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.44</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.41</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>
@@ -277,7 +277,6 @@
         <version>2.19.1</version>
         <configuration>
           <argLine>@{argLine}</argLine>
-          <skipITs>true</skipITs>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/37