### PR TITLE
Offset too early recovery and historical message replay

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.19</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.46</nukleus.kafka.spec.version>
     <reaktor.version>0.43</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.18</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.44</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.41</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KafkaErrors.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KafkaErrors.java
@@ -18,10 +18,13 @@ package org.reaktivity.nukleus.kafka.internal.stream;
 public class KafkaErrors
 {
     static final short NONE = 0;
+    static final short OFFSET_OUT_OF_RANGE = 1;
     static final short UNKNOWN_TOPIC_OR_PARTITION = 3;
     static final short LEADER_NOT_AVAILABLE = 5;
+    static final short NOT_LEADER_FOR_PARTITION = 6;
     static final short INVALID_TOPIC_EXCEPTION = 17;
     static final short TOPIC_AUTHORIZATION_FAILED = 29;
+    static final short UNKNOWN = -1;
 
     static boolean isRecoverable(short errorCode)
     {

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -522,6 +522,18 @@ public class FetchIT
     }
 
     @Test
+    @Specification(
+    {"${route}/client/controller",
+            "${client}/ktable.historical.uses.cached.key.then.live.after.offset.too.early.and.null.message/client",
+            "${server}/ktable.historical.uses.cached.key.then.live.after.offset.too.early.and.null.message/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveKTableMessagesFromLiveStreamAfterOffsetTooEarlyAndCachedKeyRemovedByNullMessage()
+            throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Specification({
         "${route}/client/controller",
         "${client}/ktable.historical.uses.cached.key.then.zero.offset/client",
@@ -624,6 +636,24 @@ public class FetchIT
     {
         k3po.start();
         k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${routeAnyTopic}/client/controller",
+        "${client}/offset.too.early.multiple.topics/client",
+        "${server}/offset.too.early.multiple.topics/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldRefetchUsingReportedFirstOffsetOnMultipleTopics() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
+        k3po.notifyBarrier("WRITE_FIRST_METADATA_RESPONSE");
+        k3po.awaitBarrier("FIRST_FETCH_REQUEST_RECEIVED");
+        k3po.notifyBarrier("WRITE_SECOND_DESCRIBE_CONFIGS_RESPONSE");
+        k3po.awaitBarrier("CLIENT_TWO_SUBSCRIBED");
+        k3po.notifyBarrier("WRITE_FIRST_FETCH_RESPONSE");
         k3po.finish();
     }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -141,19 +141,6 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/earliest.offset.message/client",
-        "${server}/earliest.offset.message/server" })
-    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldReceiveMessageAtEarliestAvailableOffset() throws Exception
-    {
-        k3po.start();
-        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${route}/client/controller",
         "${client}/fanout.with.historical.message/client",
         "${server}/fanout.with.historical.message/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
@@ -313,8 +300,8 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/fetch.key.nonzero.offset.LT.earliest.message/client",
-        "${server}/fetch.key.nonzero.offset.LT.earliest.first.matches/server"})
+        "${client}/fetch.key.nonzero.offset.too.early.message/client",
+        "${server}/fetch.key.nonzero.offset.too.early.first.matches/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldUseEarliestAvailableOffsetIfGreaterThanRequestedOffset() throws Exception
     {
@@ -624,6 +611,19 @@ public class FetchIT
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReconnectOnAbortOnLiveFetchConnection() throws Exception
     {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/offset.too.early.message/client",
+        "${server}/offset.too.early.message/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldRefetchUsingReportedFirstOffset() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
         k3po.finish();
     }
 


### PR DESCRIPTION
Changed the system for avoiding offset too early (error code 1 from fetch) by handling it entirely on the fetch connections, by having them detect the error and react by issuing a list offsets request to get the first available offset.

This allows us to recover from this condition happening in mid usage, and also corrects an issue with previous fix which caused us to reflect historical messages unnecessarily for compacted topics.

Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/38