### PR TITLE
response budget credit is computed using the slot capacity (which could

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -660,6 +660,11 @@ final class NetworkConnectionPool
                         {
                             assert networkOffset == networkLimit;
                             networkSlotOffset = 0;
+                            if (networkSlot == LOCAL_SLOT)
+                            {
+                                // so that response budget credit is computed w.r.t bufferPool slot
+                                networkSlot = NO_SLOT;
+                            }
                         }
 
                         doOfferResponseBudget();


### PR DESCRIPTION
response budget credit is computed using the slot capacity (which could
be local slot or bufferpool slot). The credit is computed between  local slot to
bufferpool slot transition and it may compute using local slot.
This may give higher credit that what can be hold in bufferpool slot.
Fixing it by setting slot to NO_SLOT early.