### PR TITLE
Added bootstrap for compacted topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ The extension data contains the following fields:
 ### Data (reply stream from nukleus-kafka)
 
 Each data frame represents the value of one Kafka message (a.k.a. record). The extension data gives the high watermark offsets which could be used subsequently to fetch all messages following this message (if the client disconnect and reconnects later).
+
+### Compacted Topics
+
+Topics which are configured in Kafka with property "cleanup.policy" set to "compact" are treated specially, in the following ways:
+
+- A cache is maintained in order to enhance performance for subscriptions to a particular message key, and where possible only deliver the latest message for the key.
+- This cache is kept up to date all the time by doing proactive fetches, unless this turned off by setting system property "nukleus.kafka.topic.bootstrap.enabled" to "false".

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.17</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.34</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.39</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.52</nukleus.kafka.spec.version>
     <reaktor.version>0.50</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.51</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.48</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.52</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.50</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
@@ -19,9 +19,22 @@ import org.reaktivity.nukleus.Configuration;
 
 public class KafkaConfiguration extends Configuration
 {
+
+    public static final String TOPIC_BOOTSTRAP_ENABLED = "nukleus.kafka.enable.topic.bootstrap";
+
+    /**
+     * @see java.nio.channels.ServerSocketChannel#bind(java.net.SocketAddress, int)
+     */
+    private static final boolean TOPIC_BOOTSTRAP_ENABLED_DEFAULT = false;
+
     public KafkaConfiguration(
         Configuration config)
     {
         super(config);
+    }
+
+    public boolean bootstrapEnabled()
+    {
+        return getBoolean(TOPIC_BOOTSTRAP_ENABLED, TOPIC_BOOTSTRAP_ENABLED_DEFAULT);
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
@@ -24,7 +24,7 @@ public class KafkaConfiguration extends Configuration
     /**
      * @see java.nio.channels.ServerSocketChannel#bind(java.net.SocketAddress, int)
      */
-    private static final boolean TOPIC_BOOTSTRAP_ENABLED_DEFAULT = false;
+    private static final boolean TOPIC_BOOTSTRAP_ENABLED_DEFAULT = true;
 
     public static final String FETCH_MAX_BYTES_PROPERTY = "nukleus.kafka.fetch.max.bytes";
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
@@ -19,11 +19,8 @@ import org.reaktivity.nukleus.Configuration;
 
 public class KafkaConfiguration extends Configuration
 {
-    public static final String TOPIC_BOOTSTRAP_ENABLED = "nukleus.kafka.enable.topic.bootstrap";
+    public static final String TOPIC_BOOTSTRAP_ENABLED = "nukleus.kafka.topic.bootstrap.enabled";
 
-    /**
-     * @see java.nio.channels.ServerSocketChannel#bind(java.net.SocketAddress, int)
-     */
     private static final boolean TOPIC_BOOTSTRAP_ENABLED_DEFAULT = true;
 
     public static final String FETCH_MAX_BYTES_PROPERTY = "nukleus.kafka.fetch.max.bytes";
@@ -36,7 +33,7 @@ public class KafkaConfiguration extends Configuration
         super(config);
     }
 
-    public boolean bootstrapEnabled()
+    public boolean topicBootstrapEnabled()
     {
         return getBoolean(TOPIC_BOOTSTRAP_ENABLED, TOPIC_BOOTSTRAP_ENABLED_DEFAULT);
     }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
@@ -89,7 +89,11 @@ public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
                       .build();
     }
 
-    public boolean handleRouteForBootstrap(int msgTypeId, DirectBuffer buffer, int index, int length)
+    public boolean handleRouteForBootstrap(
+        int msgTypeId,
+        DirectBuffer buffer,
+        int index,
+        int length)
     {
         boolean result = true;
         switch(msgTypeId)
@@ -118,7 +122,8 @@ public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
         return 0;
     }
 
-    public void startTopicBootstrap(RouteFW route)
+    public void startTopicBootstrap(
+        RouteFW route)
     {
         final OctetsFW extension = route.extension();
         if (extension.sizeof() > 0)

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
@@ -38,7 +38,10 @@ public final class KafkaNukleusFactorySpi implements NukleusFactorySpi
     {
         KafkaConfiguration kafkaConfig = new KafkaConfiguration(config);
 
-        return builder.streamFactory(CLIENT, new ClientStreamFactoryBuilder(kafkaConfig))
+        ClientStreamFactoryBuilder streamFactoryBuilder = new ClientStreamFactoryBuilder(kafkaConfig);
+
+        return builder.streamFactory(CLIENT, streamFactoryBuilder)
+                      .routeHandler(CLIENT, streamFactoryBuilder::handleRoute)
                       .build();
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
@@ -46,13 +46,9 @@ public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
         return true;
     };
     private static final Consumer<BiFunction<String, Long, NetworkConnectionPool>>
-        DEFAULT_CONNECT_POOL_FACTORY_CONSUMER = f ->
-        {
+        DEFAULT_CONNECT_POOL_FACTORY_CONSUMER = f -> {};
 
-        };
-
-    private final Map<String, Long2ObjectHashMap<NetworkConnectionPool>> connectionPools =
-                      new LinkedHashMap<String, Long2ObjectHashMap<NetworkConnectionPool>>();
+    private final Map<String, Long2ObjectHashMap<NetworkConnectionPool>> connectionPools = new LinkedHashMap<>();
 
     private final RouteFW routeRO = new RouteFW();
     private final KafkaRouteExFW routeExRO = new KafkaRouteExFW();
@@ -78,7 +74,7 @@ public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
             DEFAULT_CONNECT_POOL_FACTORY_CONSUMER;
         MessagePredicate routeHandler = DEFAULT_ROUTE_HANDLER;
 
-        if (kafkaConfig.bootstrapEnabled())
+        if (kafkaConfig.topicBootstrapEnabled())
         {
             routeHandler = this::handleRouteForBootstrap;
             connectionPoolFactoryConsumer = f -> createNetworkConnectionPool = f;
@@ -129,7 +125,6 @@ public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
         {
             final KafkaRouteExFW routeEx = extension.get(routeExRO::wrap);
             final String topicName = routeEx.topicName().asString();
-            System.out.println(String.format("Starting bootstrap for topic %s on route \"%s\"", topicName, route));
 
             final String networkName = route.target().asString();
             final long networkRef = route.targetRef();

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
@@ -115,8 +115,9 @@ public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
     {
         if (pendingRoute != null && createNetworkConnectionPool != null)
         {
-            startTopicBootstrap(pendingRoute);
+            final RouteFW route = pendingRoute;
             pendingRoute = null;
+            startTopicBootstrap(route);
         }
         return 0;
     }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -15,7 +15,6 @@
  */
 package org.reaktivity.nukleus.kafka.internal.stream;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
@@ -157,33 +156,6 @@ public final class ClientStreamFactory implements StreamFactory
         }
 
         return newStream;
-    }
-
-    public void startTopicBootstrap(RouteFW route)
-    {
-        final OctetsFW extension = route.extension();
-        if (extension.sizeof() > 0)
-        {
-            final KafkaRouteExFW routeEx = extension.get(routeExRO::wrap);
-            final String topicName = routeEx.topicName().asString();
-            System.out.println(String.format("Starting bootstrap for topic %s on route \"%s\"", topicName, route));
-
-            final String networkName = route.target().asString();
-            final long networkRef = route.targetRef();
-
-            Long2ObjectHashMap<NetworkConnectionPool> connectionPoolsByRef =
-                connectionPools.computeIfAbsent(networkName, this::newConnectionPoolsByRef);
-
-            NetworkConnectionPool connectionPool = connectionPoolsByRef.computeIfAbsent(networkRef, ref ->
-                new NetworkConnectionPool(this, networkName, ref, fetchMaxBytes, bufferPool));
-
-            connectionPool.doBootstrap(topicName, errorCode ->
-            {
-                throw new IllegalStateException(format(
-                    " Received error code %d from Kafka while attempting to bootstrap topic \"%s\"",
-                    errorCode, topicName));
-            });
-        }
     }
 
     private MessageConsumer newAcceptStream(

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactoryBuilder.java
@@ -20,6 +20,7 @@ import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
+import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.reaktivity.nukleus.buffer.BufferPool;
@@ -107,5 +108,11 @@ public final class ClientStreamFactoryBuilder implements StreamFactoryBuilder
 
         return new ClientStreamFactory(config, router, writeBuffer, bufferPool,
                 supplyStreamId, supplyCorrelationId, correlations);
+    }
+
+    public boolean handleRoute(int msgTypeId, DirectBuffer buffer, int index, int length)
+    {
+        boolean result = true;
+        return result;
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactoryBuilder.java
@@ -20,7 +20,6 @@ import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
-import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.reaktivity.nukleus.buffer.BufferPool;
@@ -108,11 +107,5 @@ public final class ClientStreamFactoryBuilder implements StreamFactoryBuilder
 
         return new ClientStreamFactory(config, router, writeBuffer, bufferPool,
                 supplyStreamId, supplyCorrelationId, correlations);
-    }
-
-    public boolean handleRoute(int msgTypeId, DirectBuffer buffer, int index, int length)
-    {
-        boolean result = true;
-        return result;
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactoryBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.reaktivity.nukleus.kafka.internal.stream;
 
+import java.util.function.Consumer;
 import java.util.function.IntUnaryOperator;
 import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
@@ -24,6 +25,7 @@ import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.reaktivity.nukleus.buffer.BufferPool;
 import org.reaktivity.nukleus.kafka.internal.KafkaConfiguration;
+import org.reaktivity.nukleus.kafka.internal.types.control.RouteFW;
 import org.reaktivity.nukleus.route.RouteManager;
 import org.reaktivity.nukleus.stream.StreamFactory;
 import org.reaktivity.nukleus.stream.StreamFactoryBuilder;
@@ -31,6 +33,7 @@ import org.reaktivity.nukleus.stream.StreamFactoryBuilder;
 public final class ClientStreamFactoryBuilder implements StreamFactoryBuilder
 {
     private final KafkaConfiguration config;
+    private final Consumer<Consumer<RouteFW>> registerTopicBootstrapper;
     private final Long2ObjectHashMap<NetworkConnectionPool.AbstractNetworkConnection> correlations;
 
     private RouteManager router;
@@ -40,9 +43,11 @@ public final class ClientStreamFactoryBuilder implements StreamFactoryBuilder
     private Supplier<BufferPool> supplyBufferPool;
 
     public ClientStreamFactoryBuilder(
-        KafkaConfiguration config)
+        KafkaConfiguration config,
+        Consumer<Consumer<RouteFW>> registerTopicBootstrapper)
     {
         this.config = config;
+        this.registerTopicBootstrapper = registerTopicBootstrapper;
         this.correlations = new Long2ObjectHashMap<>();
     }
 
@@ -106,6 +111,6 @@ public final class ClientStreamFactoryBuilder implements StreamFactoryBuilder
         final BufferPool bufferPool = supplyBufferPool.get();
 
         return new ClientStreamFactory(config, router, writeBuffer, bufferPool,
-                supplyStreamId, supplyCorrelationId, correlations);
+                supplyStreamId, supplyCorrelationId, correlations, registerTopicBootstrapper);
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1580,7 +1580,7 @@ public final class NetworkConnectionPool
         private final PartitionProgressHandler progressHandler;
 
         private BitSet needsHistoricalByPartition = new BitSet();
-        private final boolean bootstrap;
+        private final boolean proactive;
 
         private final class BootstrapMessageDispatcher  implements MessageDispatcher
         {
@@ -1626,7 +1626,7 @@ public final class NetworkConnectionPool
             String topicName,
             int partitionCount,
             boolean compacted,
-            boolean bootstrap)
+            boolean proactive)
         {
             this.topicName = topicName;
             this.compacted = compacted;
@@ -1636,8 +1636,8 @@ public final class NetworkConnectionPool
             this.progressHandler = this::handleProgress;
             this.dispatcher = new TopicMessageDispatcher(partitionCount,
                     compacted ? CachingKeyMessageDispatcher::new : KeyMessageDispatcher::new);
-            this.bootstrap = bootstrap;
-            if (bootstrap)
+            this.proactive = proactive;
+            if (proactive)
             {
                  for (int i=0; i < partitionCount; i++)
                  {
@@ -1878,7 +1878,7 @@ public final class NetworkConnectionPool
         int maximumWritableBytes(boolean live)
         {
             int writableBytes = 0;
-            if (live && bootstrap)
+            if (live && proactive)
             {
                 writableBytes = bufferPool.slotCapacity();
             }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -101,7 +101,7 @@ import org.reaktivity.nukleus.kafka.internal.types.stream.TcpBeginExFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.WindowFW;
 import org.reaktivity.nukleus.kafka.internal.util.BufferUtil;
 
-final class NetworkConnectionPool
+public final class NetworkConnectionPool
 {
     private static final short FETCH_API_VERSION = 5;
     private static final short FETCH_API_KEY = 1;
@@ -284,33 +284,66 @@ final class NetworkConnectionPool
                     fetchOffsets.put(partition, offset);
                 }
             }
-            finishAttach(topicName, fetchOffsets, fetchKey, headers, dispatcher, supplyWindow,
-                    progressHandlerConsumer, newAttachDetailsConsumer, topicMetadata);
+            final NetworkTopic topic = topicsByName.computeIfAbsent(topicName,
+                    name -> new NetworkTopic(name, topicMetadata.partitionCount(), topicMetadata.compacted, false));
+            progressHandlerConsumer.accept(topic.doAttach(fetchOffsets, fetchKey, headers, dispatcher, supplyWindow));
+            final int newAttachId = nextAttachId++;
+            detachersById.put(newAttachId, f -> topic.doDetach(f, fetchKey, headers, dispatcher, supplyWindow));
+            doConnections(topicMetadata);
+            newAttachDetailsConsumer.accept(newAttachId, topicMetadata.compacted);
             break;
         default:
             throw new RuntimeException(format("Unexpected errorCode %d from metadata query", errorCode));
         }
     }
 
-    private void finishAttach(
+    public void doBootstrap(
         String topicName,
-        Long2LongHashMap fetchOffsets,
-        OctetsFW fetchKey,
-        ListFW<KafkaHeaderFW> headers,
-        MessageDispatcher dispatcher,
-        IntSupplier supplyWindow,
-        Consumer<PartitionProgressHandler> progressHandlerConsumer,
-        IntBooleanConsumer newAttachDetailsConsumer,
+        IntConsumer onMetadataError)
+    {
+        final TopicMetadata metadata = topicMetadataByName.computeIfAbsent(topicName, TopicMetadata::new);
+        metadata.doAttach(m -> doBootstrap(topicName, onMetadataError, m));
+
+        if (metadataConnection == null)
+        {
+            metadataConnection = new MetadataConnection();
+        }
+        metadataConnection.doRequestIfNeeded();
+    }
+
+    private void doBootstrap(
+        String topicName,
+        IntConsumer onMetadataError,
         TopicMetadata topicMetadata)
     {
-        final NetworkTopic topic = topicsByName.computeIfAbsent(topicName,
-                name -> new NetworkTopic(name, topicMetadata.partitionCount(), topicMetadata.compacted));
-        progressHandlerConsumer.accept(topic.doAttach(fetchOffsets, fetchKey, headers, dispatcher, supplyWindow));
+        short errorCode = topicMetadata.errorCode();
+        switch(errorCode)
+        {
+        case UNKNOWN_TOPIC_OR_PARTITION:
+            onMetadataError.accept(errorCode);
+            break;
+        case INVALID_TOPIC_EXCEPTION:
+            onMetadataError.accept(errorCode);
+            break;
+        case LEADER_NOT_AVAILABLE:
+            // recoverable
+            break;
+        case NONE:
+            if (topicMetadata.compacted)
+            {
+                topicsByName.computeIfAbsent(topicName,
+                        name -> new NetworkTopic(name, topicMetadata.partitionCount(), topicMetadata.compacted, true));
+                doConnections(topicMetadata);
+                doFlush();
+            }
+            break;
+        default:
+            throw new RuntimeException(format("Unexpected errorCode %d from metadata query", errorCode));
+        }
+    }
 
-        final int newAttachId = nextAttachId++;
-
-        detachersById.put(newAttachId, f -> topic.doDetach(f, fetchKey, headers, dispatcher, supplyWindow));
-
+    private void doConnections(TopicMetadata topicMetadata)
+    {
         topicMetadata.visitBrokers(broker ->
         {
             connections = applyBrokerMetadata(connections, broker, LiveFetchConnection::new);
@@ -319,7 +352,6 @@ final class NetworkConnectionPool
         {
             historicalConnections = applyBrokerMetadata(historicalConnections, broker,  HistoricalFetchConnection::new);
         });
-        newAttachDetailsConsumer.accept(newAttachId, topicMetadata.compacted);
     }
 
     private <T extends AbstractFetchConnection> T[] applyBrokerMetadata(
@@ -1141,7 +1173,7 @@ final class NetworkConnectionPool
             IntLongConsumer partitionOffsets)
         {
             final NetworkTopic topic = topicsByName.get(topicName);
-            final int maxPartitionBytes = limitMaximumBytes(topic.maximumWritableBytes());
+            final int maxPartitionBytes = limitMaximumBytes(topic.maximumWritableBytes(true));
 
             int partitionCount = 0;
 
@@ -1198,7 +1230,7 @@ final class NetworkConnectionPool
             NetworkTopic topic = topicsByName.get(topicName);
             if (topic.needsHistorical())
             {
-                final int maxPartitionBytes = limitMaximumBytes(topic.maximumWritableBytes());
+                final int maxPartitionBytes = limitMaximumBytes(topic.maximumWritableBytes(false));
                 if (maxPartitionBytes > 0)
                 {
                     final TopicMetadata metadata = topicMetadataByName.get(topicName);
@@ -1548,6 +1580,7 @@ final class NetworkConnectionPool
         private final PartitionProgressHandler progressHandler;
 
         private BitSet needsHistoricalByPartition = new BitSet();
+        private final boolean bootstrap;
 
         @Override
         public String toString()
@@ -1558,7 +1591,8 @@ final class NetworkConnectionPool
         NetworkTopic(
             String topicName,
             int partitionCount,
-            boolean compacted)
+            boolean compacted,
+            boolean bootstrap)
         {
             this.topicName = topicName;
             this.compacted = compacted;
@@ -1568,6 +1602,14 @@ final class NetworkConnectionPool
             this.progressHandler = this::handleProgress;
             this.dispatcher = new TopicMessageDispatcher(partitionCount,
                     compacted ? CachingKeyMessageDispatcher::new : KeyMessageDispatcher::new);
+            this.bootstrap = bootstrap;
+            if (bootstrap)
+            {
+                 for (int i=0; i < partitionCount; i++)
+                 {
+                     attachToPartition(i, 0L, 1);
+                 }
+            }
         }
 
         PartitionProgressHandler doAttach(
@@ -1797,16 +1839,22 @@ final class NetworkConnectionPool
             }
         }
 
-        int maximumWritableBytes()
+        int maximumWritableBytes(boolean live)
         {
-            // TODO: eliminate iterator allocation
-            int writeableBytes = 0;
-            for (IntSupplier supplyWindow : windowSuppliers)
+            int writableBytes = 0;
+            if (live && bootstrap)
             {
-                writeableBytes = Math.max(writeableBytes, supplyWindow.getAsInt());
+                writableBytes = bufferPool.slotCapacity();
             }
-
-            return writeableBytes;
+            else
+            {
+                // TODO: eliminate iterator allocation
+                for (IntSupplier supplyWindow : windowSuppliers)
+                {
+                    writableBytes = Math.max(writableBytes, supplyWindow.getAsInt());
+                }
+            }
+            return writableBytes;
         }
 
         private void handleProgress(

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/control/ControlIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/control/ControlIT.java
@@ -26,6 +26,7 @@ import org.junit.rules.Timeout;
 import org.kaazing.k3po.junit.annotation.ScriptProperty;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
+import org.reaktivity.nukleus.kafka.internal.KafkaConfiguration;
 import org.reaktivity.reaktor.test.ReaktorRule;
 
 public class ControlIT
@@ -44,7 +45,8 @@ public class ControlIT
             .directory("target/nukleus-itests")
             .commandBufferCapacity(1024)
             .responseBufferCapacity(1024)
-            .counterValuesBufferCapacity(1024);
+            .counterValuesBufferCapacity(1024)
+            .configure(KafkaConfiguration.TOPIC_BOOTSTRAP_ENABLED, "false");
 
     @Rule
     public final TestRule chain = outerRule(k3po).around(timeout).around(reaktor);

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.k3po.junit.annotation.ScriptProperty;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.reaktivity.nukleus.kafka.internal.KafkaConfiguration;
+import org.reaktivity.reaktor.test.ReaktorRule;
+
+public class BootstrapIT
+{
+    private final K3poRule k3po = new K3poRule()
+            .addScriptRoot("route", "org/reaktivity/specification/nukleus/kafka/control/route.ext")
+            .addScriptRoot("routeAnyTopic", "org/reaktivity/specification/nukleus/kafka/control/route")
+            .addScriptRoot("server", "org/reaktivity/specification/kafka/fetch.v5")
+            .addScriptRoot("metadata", "org/reaktivity/specification/kafka/metadata.v5")
+            .addScriptRoot("client", "org/reaktivity/specification/nukleus/kafka/streams/fetch");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+
+    private final ReaktorRule reaktor = new ReaktorRule()
+        .nukleus("kafka"::equals)
+        .directory("target/nukleus-itests")
+        .commandBufferCapacity(1024)
+        .responseBufferCapacity(1024)
+        .counterValuesBufferCapacity(1024)
+        .configure(KafkaConfiguration.TOPIC_BOOTSTRAP_ENABLED, "true")
+        .clean();
+
+    @Rule
+    public final TestRule chain = outerRule(reaktor).around(k3po).around(timeout);
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/fetch.key.zero.offset.three.messages/client",
+        "${server}/fetch.key.three.matches.flow.controlled/server"})
+    @ScriptProperty({"networkAccept \"nukleus://target/streams/kafka\"",
+                     "applicationConnectWindow 15"})
+    public void shouldReceiveMessagesThreeMatchingFetchKeyFlowControlled() throws Exception
+    {
+        k3po.finish();
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
@@ -86,7 +86,7 @@ public class BootstrapIT
 
     @Test
     @Specification({
-        "${control}/route.ext.multiple.networks/client/controller",
+        "${control}/route/client/controller",
         "${client}/no.offsets.message/client",
         "${server}/zero.offset.message/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
@@ -110,7 +110,6 @@ public class BootstrapIT
 
     @Test
     @Specification({
-        "${route}/client/controller",
         "${route}/client/controller",
         "${client}/ktable.bootstrap.historical.uses.cached.key.then.live/client",
         "${server}/ktable.bootstrap.historical.uses.cached.key.then.live/server"})

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
@@ -33,6 +33,7 @@ public class BootstrapIT
     private final K3poRule k3po = new K3poRule()
             .addScriptRoot("route", "org/reaktivity/specification/nukleus/kafka/control/route.ext")
             .addScriptRoot("routeAnyTopic", "org/reaktivity/specification/nukleus/kafka/control/route")
+            .addScriptRoot("control", "org/reaktivity/specification/nukleus/kafka/control")
             .addScriptRoot("server", "org/reaktivity/specification/kafka/fetch.v5")
             .addScriptRoot("metadata", "org/reaktivity/specification/kafka/metadata.v5")
             .addScriptRoot("client", "org/reaktivity/specification/nukleus/kafka/streams/fetch");
@@ -53,9 +54,9 @@ public class BootstrapIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${server}/bootstrap/server"})
+        "${server}/ktable.message/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldBootstrapWhenTopicBootstrapIsEnabledAndTopicIsCompacted() throws Exception
+    public void shouldBootstrapTopic() throws Exception
     {
         k3po.finish();
     }
@@ -63,6 +64,29 @@ public class BootstrapIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${server}/ktable.messages.multiple.nodes/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldBootstrapTopicWithMultiplePartitionsOnMultipleNodes() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${control}/route.ext.multiple.topics/client/controller",
+        "${server}/ktable.messages.multiple.topics/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldBootstrapMultipleTopics() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("SECOND_METADATA_RESPONSE_WRITTEN");
+        k3po.notifyBarrier("WRITE_FIRST_FETCH_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${control}/route.ext.multiple.networks/client/controller",
         "${client}/no.offsets.message/client",
         "${server}/zero.offset.message/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
@@ -72,4 +96,33 @@ public class BootstrapIT
         k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${routeAnyTopic}/client/controller",
+        "${client}/ktable.message/client",
+        "${server}/ktable.message/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldNotBootstrapWhenRouteDoesNotNameATopic() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${route}/client/controller",
+        "${client}/ktable.bootstrap.historical.uses.cached.key.then.live/client",
+        "${server}/ktable.bootstrap.historical.uses.cached.key.then.live/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldBootstrapTopicAndUseCachedKeyOffsetThenLive() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("SECOND_LIVE_FETCH_REQUEST_RECEIVED");
+        k3po.notifyBarrier("CONNECT_CLIENT");
+        k3po.awaitBarrier("HISTORICAL_FETCH_REQUEST_RECEIVED");
+        k3po.notifyBarrier("DELIVER_SECOND_LIVE_FETCH_RESPONSE");
+        k3po.finish();
+    }
+
 }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
@@ -73,8 +73,20 @@ public class BootstrapIT
 
     @Test
     @Specification({
+        "${control}/route.ext.multiple.networks/client/controller",
+        "${server}/ktable.message.multiple.networks/server"})
+    @ScriptProperty({
+        "networkAccept1 \"nukleus://target1/streams/kafka\"",
+        "networkAccept2 \"nukleus://target2/streams/kafka\""})
+    public void shouldBootstrapMultipleNetworks() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${control}/route.ext.multiple.topics/client/controller",
-        "${server}/ktable.messages.multiple.topics/server"})
+        "${server}/ktable.message.multiple.topics/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldBootstrapMultipleTopics() throws Exception
     {
@@ -120,6 +132,8 @@ public class BootstrapIT
         k3po.awaitBarrier("SECOND_LIVE_FETCH_REQUEST_RECEIVED");
         k3po.notifyBarrier("CONNECT_CLIENT");
         k3po.awaitBarrier("HISTORICAL_FETCH_REQUEST_RECEIVED");
+        k3po.notifyBarrier("DELIVER_HISTORICAL_FETCH_RESPONSE");
+        k3po.awaitBarrier("HISTORICAL_FETCH_RESPONSE_WRITTEN");
         k3po.notifyBarrier("DELIVER_SECOND_LIVE_FETCH_RESPONSE");
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
@@ -45,7 +45,6 @@ public class BootstrapIT
         .commandBufferCapacity(1024)
         .responseBufferCapacity(1024)
         .counterValuesBufferCapacity(1024)
-        //.configure(KafkaConfiguration.TOPIC_BOOTSTRAP_ENABLED, "true")
         .clean();
 
     @Rule
@@ -58,6 +57,19 @@ public class BootstrapIT
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldBootstrapWhenTopicBootstrapIsEnabledAndTopicIsCompacted() throws Exception
     {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/no.offsets.message/client",
+        "${server}/zero.offset.message/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldNotBootstrapWhenTopicBootstrapIsEnabledButTopicIsNotCompacted() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
         k3po.finish();
     }
 }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
@@ -26,7 +26,6 @@ import org.junit.rules.Timeout;
 import org.kaazing.k3po.junit.annotation.ScriptProperty;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
-import org.reaktivity.nukleus.kafka.internal.KafkaConfiguration;
 import org.reaktivity.reaktor.test.ReaktorRule;
 
 public class BootstrapIT
@@ -46,7 +45,7 @@ public class BootstrapIT
         .commandBufferCapacity(1024)
         .responseBufferCapacity(1024)
         .counterValuesBufferCapacity(1024)
-        .configure(KafkaConfiguration.TOPIC_BOOTSTRAP_ENABLED, "true")
+        //.configure(KafkaConfiguration.TOPIC_BOOTSTRAP_ENABLED, "true")
         .clean();
 
     @Rule
@@ -55,11 +54,9 @@ public class BootstrapIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/fetch.key.zero.offset.three.messages/client",
-        "${server}/fetch.key.three.matches.flow.controlled/server"})
-    @ScriptProperty({"networkAccept \"nukleus://target/streams/kafka\"",
-                     "applicationConnectWindow 15"})
-    public void shouldReceiveMessagesThreeMatchingFetchKeyFlowControlled() throws Exception
+        "${server}/bootstrap/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldBootstrapWhenTopicBootstrapIsEnabledAndTopicIsCompacted() throws Exception
     {
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -621,8 +621,8 @@ public class FetchIT
     @Test
     @Specification({
         "${control}/route.ext.multiple.topics/client/controller",
-        "${client}/ktable.messages.multiple.topics/client",
-        "${server}/ktable.messages.multiple.topics/server"})
+        "${client}/ktable.message.multiple.topics/client",
+        "${server}/ktable.message.multiple.topics/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveMessagesFromMultipleTopics() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -627,7 +627,7 @@ public class FetchIT
     public void shouldReceiveMessagesFromMultipleTopics() throws Exception
     {
         k3po.start();
-        k3po.awaitBarrier("SECOND_METADATA_RESPONSE_WRITTEN");
+        k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
         k3po.notifyBarrier("WRITE_FIRST_FETCH_RESPONSE");
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -35,6 +35,7 @@ public class FetchIT
     private final K3poRule k3po = new K3poRule()
             .addScriptRoot("route", "org/reaktivity/specification/nukleus/kafka/control/route.ext")
             .addScriptRoot("routeAnyTopic", "org/reaktivity/specification/nukleus/kafka/control/route")
+            .addScriptRoot("control", "org/reaktivity/specification/nukleus/kafka/control")
             .addScriptRoot("server", "org/reaktivity/specification/kafka/fetch.v5")
             .addScriptRoot("metadata", "org/reaktivity/specification/kafka/metadata.v5")
             .addScriptRoot("client", "org/reaktivity/specification/nukleus/kafka/streams/fetch");
@@ -614,6 +615,20 @@ public class FetchIT
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveKTableMessagesFromMultipleNodes() throws Exception
     {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${control}/route.ext.multiple.topics/client/controller",
+        "${client}/ktable.messages.multiple.topics/client",
+        "${server}/ktable.messages.multiple.topics/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveMessagesFromMultipleTopics() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("SECOND_METADATA_RESPONSE_WRITTEN");
+        k3po.notifyBarrier("WRITE_FIRST_FETCH_RESPONSE");
         k3po.finish();
     }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -27,6 +27,7 @@ import org.junit.rules.Timeout;
 import org.kaazing.k3po.junit.annotation.ScriptProperty;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
+import org.reaktivity.nukleus.kafka.internal.KafkaConfiguration;
 import org.reaktivity.reaktor.test.ReaktorRule;
 
 public class FetchIT
@@ -46,6 +47,7 @@ public class FetchIT
         .commandBufferCapacity(1024)
         .responseBufferCapacity(1024)
         .counterValuesBufferCapacity(1024)
+        .configure(KafkaConfiguration.TOPIC_BOOTSTRAP_ENABLED, "false")
         .clean();
 
     @Rule

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -49,6 +49,7 @@ public class FetchLimitsIT
         .responseBufferCapacity(1024)
         .counterValuesBufferCapacity(1024)
         .clean()
+        .configure(KafkaConfiguration.TOPIC_BOOTSTRAP_ENABLED, "false")
         .configure(ReaktorConfiguration.BUFFER_SLOT_CAPACITY_PROPERTY, 256)
         .configure(KafkaConfiguration.FETCH_MAX_BYTES_PROPERTY, 256);
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MetadataIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MetadataIT.java
@@ -26,6 +26,7 @@ import org.junit.rules.Timeout;
 import org.kaazing.k3po.junit.annotation.ScriptProperty;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
+import org.reaktivity.nukleus.kafka.internal.KafkaConfiguration;
 import org.reaktivity.reaktor.test.ReaktorRule;
 
 public class MetadataIT
@@ -44,6 +45,7 @@ public class MetadataIT
         .commandBufferCapacity(1024)
         .responseBufferCapacity(1024)
         .counterValuesBufferCapacity(1024)
+        .configure(KafkaConfiguration.TOPIC_BOOTSTRAP_ENABLED, "false")
         .clean();
 
     @Rule


### PR DESCRIPTION
Topics which have explicit routes are automatically bootstrapped as soon as they are routed, if they are compacted. Bootstrap consists of reading all messages in order to populate the key offsets cache (in CachingKeyMessageDispatcher).

 Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/42

Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/43 to fix build failures