### PR TITLE
Issue a warning instead of a hard fail when bootstrap fails with "unknown topic" error code 3

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
@@ -16,6 +16,7 @@
 package org.reaktivity.nukleus.kafka.internal;
 
 import static java.lang.String.format;
+import static org.reaktivity.nukleus.kafka.internal.stream.KafkaErrors.UNKNOWN_TOPIC_OR_PARTITION;
 import static org.reaktivity.nukleus.route.RouteKind.CLIENT;
 
 import java.util.ArrayList;
@@ -149,9 +150,18 @@ public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
 
                 connectionPool.doBootstrap(topicName, errorCode ->
                 {
-                    throw new IllegalStateException(format(
-                        " Received error code %d from Kafka while attempting to bootstrap topic \"%s\"",
-                        errorCode, topicName));
+                    switch(errorCode)
+                    {
+                    case UNKNOWN_TOPIC_OR_PARTITION:
+                        System.out.println(format(
+                            "WARNING: bootstrap failed for topic \"%s\" with error \"unknown topic\"",
+                            topicName));
+                        break;
+                    default:
+                        throw new IllegalStateException(format(
+                            "Received error code %d from Kafka while attempting to bootstrap topic \"%s\"",
+                            errorCode, topicName));
+                    }
                 });
             }
         }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KafkaErrors.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KafkaErrors.java
@@ -19,7 +19,7 @@ public class KafkaErrors
 {
     static final short NONE = 0;
     static final short OFFSET_OUT_OF_RANGE = 1;
-    static final short UNKNOWN_TOPIC_OR_PARTITION = 3;
+    public static final short UNKNOWN_TOPIC_OR_PARTITION = 3;
     static final short LEADER_NOT_AVAILABLE = 5;
     static final short NOT_LEADER_FOR_PARTITION = 6;
     static final short INVALID_TOPIC_EXCEPTION = 17;


### PR DESCRIPTION
I have spec tests ready which will be included in a separate PR I am doing anyway to add more tests. That allow this PR  to be more easily merged and released if so decided.