### PR TITLE
Bootstrap more tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.53</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.50</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
@@ -86,6 +86,9 @@ public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
 
         return builder.streamFactory(CLIENT, streamFactoryBuilder)
                       .routeHandler(CLIENT, routeHandler)
+                      //.unrouteExtensionPredicate BuffersPredicate
+                      // boolean test(buffer1, offset1, length1, buffer2, offset2, length2)
+                      // or compare extensions in Router.routeMatchesUnroute
                       .inject(this)
                       .build();
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/control/ControlIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/control/ControlIT.java
@@ -32,6 +32,7 @@ import org.reaktivity.reaktor.test.ReaktorRule;
 public class ControlIT
 {
     private final K3poRule k3po = new K3poRule()
+            .addScriptRoot("control", "org/reaktivity/specification/nukleus/kafka/control")
             .addScriptRoot("route", "org/reaktivity/specification/nukleus/kafka/control/route")
             .addScriptRoot("unroute", "org/reaktivity/specification/nukleus/kafka/control/unroute")
             .addScriptRoot("routeEx", "org/reaktivity/specification/nukleus/kafka/control/route.ext")
@@ -81,10 +82,48 @@ public class ControlIT
 
     @Test
     @Specification({
+        "${control}/route.ext.multiple.networks/client/controller"
+    })
+    public void shouldRouteClientWithMultipleRoutesDifferentNetworks() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${control}/route.ext.multiple.topics/client/controller"
+    })
+    public void shouldRouteClientWithMultipleRoutesDifferentTopics() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${routeEx}/client/controller",
         "${unrouteEx}/client/controller"
     })
     public void shouldUnrouteClientWithExtension() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${control}/route.ext.multiple.networks/client/controller",
+        "${control}/unroute.ext.multiple.networks/client/controller"
+    })
+    public void shouldUnrouteClientMultipleRoutesDifferentNetworks() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${control}/route.ext.multiple.topics/client/controller",
+        "${control}/unroute.ext.multiple.topics/client/controller"
+    })
+    public void shouldUnrouteClientMultipleRoutesDifferentTopics() throws Exception
     {
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/control/ControlIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/control/ControlIT.java
@@ -18,6 +18,7 @@ package org.reaktivity.nukleus.kafka.internal.control;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -118,6 +119,7 @@ public class ControlIT
         k3po.finish();
     }
 
+    @Ignore("TODO: first unroute currently removes both routes, need a way to compare unroute and route extensions")
     @Test
     @Specification({
         "${control}/route.ext.multiple.topics/client/controller",

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/control/ControllerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/control/ControllerIT.java
@@ -194,6 +194,40 @@ public class ControllerIT
 
     @Test
     @Specification({
+        "${control}/route.ext.multiple.networks/client/nukleus",
+        "${control}/unroute.ext.multiple.networks/client/nukleus"
+    })
+    public void shouldUnrouteClientWithMultipleRoutesDifferentNetworks() throws Exception
+    {
+        long targetRef1 = new Random().nextLong();
+        long targetRef2 = new Random().nextLong();
+        String topicName = "test";
+
+        k3po.start();
+
+        long applicationRouteRef1 = reaktor.controller(KafkaController.class)
+               .routeClient("source", 0L, "target1", targetRef1, topicName)
+               .get();
+
+        long applicationRouteRef2 = reaktor.controller(KafkaController.class)
+               .routeClient("source", 0L, "target2", targetRef2, topicName)
+               .get();
+
+        k3po.notifyBarrier("ROUTED_CLIENT");
+
+        reaktor.controller(KafkaController.class)
+               .unrouteClient("source", applicationRouteRef1, "target1",  targetRef1, topicName)
+               .get();
+
+        reaktor.controller(KafkaController.class)
+               .unrouteClient("source", applicationRouteRef2, "target2",  targetRef2, topicName)
+               .get();
+
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${freeze}/nukleus"
     })
     @ScriptProperty("nameF00N \"kafka\"")

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/control/ControllerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/control/ControllerIT.java
@@ -16,9 +16,12 @@
 package org.reaktivity.nukleus.kafka.internal.control;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.rules.RuleChain.outerRule;
 
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +37,7 @@ import org.reaktivity.reaktor.test.ReaktorRule;
 public class ControllerIT
 {
     private final K3poRule k3po = new K3poRule()
+        .addScriptRoot("control", "org/reaktivity/specification/nukleus/kafka/control")
         .addScriptRoot("route", "org/reaktivity/specification/nukleus/kafka/control/route")
         .addScriptRoot("unroute", "org/reaktivity/specification/nukleus/kafka/control/unroute")
         .addScriptRoot("routeEx", "org/reaktivity/specification/nukleus/kafka/control/route.ext")
@@ -112,6 +116,56 @@ public class ControllerIT
         k3po.finish();
     }
 
+    @Test
+    @Specification({
+        "${control}/route.ext.multiple.networks/client/nukleus"
+    })
+    public void shouldRouteClientWithMultipleRoutesDifferentNetworks() throws Exception
+    {
+        long targetRef1 = new Random().nextLong();
+        long targetRef2 = new Random().nextLong();
+        String topicName = "test";
+
+        k3po.start();
+
+        long applicationRouteRef1 = reaktor.controller(KafkaController.class)
+               .routeClient("source", 0L, "target1", targetRef1, topicName)
+               .get();
+
+        long applicationRouteRef2 = reaktor.controller(KafkaController.class)
+               .routeClient("source", 0L, "target2", targetRef2, topicName)
+               .get();
+
+        assertNotEquals(applicationRouteRef1, applicationRouteRef2);
+
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${control}/route.ext.multiple.topics/client/nukleus"
+    })
+    public void shouldRouteClientWithMultipleRoutesDifferentTopics() throws Exception
+    {
+        long targetRef = new Random().nextLong();
+
+        k3po.start();
+
+        Long applicationRouteRef = reaktor.controller(KafkaController.class)
+               .routeClient("source", 0L, "target", targetRef, "test1")
+               .get();
+
+        CompletableFuture<Long> result2 = reaktor.controller(KafkaController.class)
+               .routeClient("source", applicationRouteRef, "target", targetRef, "test2");
+
+        CompletableFuture<Long> result3 = reaktor.controller(KafkaController.class)
+               .routeClient("source", applicationRouteRef, "target", targetRef, "test3");
+
+        assertEquals(applicationRouteRef, result2.get());
+        assertEquals(applicationRouteRef, result3.get());
+
+        k3po.finish();
+    }
 
     @Test
     @Specification({

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
@@ -138,4 +138,14 @@ public class BootstrapIT
         k3po.finish();
     }
 
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${metadata}/one.topic.error.unknown.topic/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldIssueWarningWhenBootstrapUnkownTopic() throws Exception
+    {
+        k3po.finish();
+    }
+
 }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
@@ -93,6 +93,30 @@ public class BootstrapIT
         k3po.start();
         k3po.awaitBarrier("SECOND_METADATA_RESPONSE_WRITTEN");
         k3po.notifyBarrier("WRITE_FIRST_FETCH_RESPONSE");
+        k3po.notifyBarrier("WRITE_SECOND_FETCH_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/ktable.message/client",
+        "${server}/ktable.bootstrap.uses.historical/server"})
+    @ScriptProperty({"networkAccept \"nukleus://target/streams/kafka\"",
+                     "offset \"4\""
+    })
+    public void shouldBootstrapWithHistoricalWhenClientSubscribesAtHigherOffset() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_CLIENT");
+        k3po.awaitBarrier("FIRST_LIVE_FETCH_REQUEST_RECEIVED");
+        k3po.notifyBarrier("CONNECT_CLIENT");
+        k3po.awaitBarrier("CLIENT_CONNECTED");
+        k3po.notifyBarrier("WRITE_FIRST_LIVE_FETCH_RESPONSE");
+        k3po.awaitBarrier("SECOND_LIVE_FETCH_REQUEST_RECEIVED");
+        k3po.awaitBarrier("HISTORICAL_FETCH_REQUEST_RECEIVED");
+        k3po.notifyBarrier("WRITE_HISTORICAL_FETCH_RESPONSE");
+        k3po.notifyBarrier("WRITE_SECOND_LIVE_FETCH_RESPONSE");
         k3po.finish();
     }
 
@@ -117,6 +141,9 @@ public class BootstrapIT
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldNotBootstrapWhenRouteDoesNotNameATopic() throws Exception
     {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_CLIENT");
+        k3po.notifyBarrier("CONNECT_CLIENT");
         k3po.finish();
     }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -556,6 +556,9 @@ public class FetchIT
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveKtableMessage() throws Exception
     {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_CLIENT");
+        k3po.notifyBarrier("CONNECT_CLIENT");
         k3po.finish();
     }
 
@@ -629,6 +632,8 @@ public class FetchIT
         k3po.start();
         k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
         k3po.notifyBarrier("WRITE_FIRST_FETCH_RESPONSE");
+        k3po.awaitBarrier("CLIENT_THREE_CONNECTED");
+        k3po.notifyBarrier("WRITE_SECOND_FETCH_RESPONSE");
         k3po.finish();
     }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -117,7 +117,7 @@ public class FetchIT
     @Specification({
         "${routeAnyTopic}/client/controller",
         "${client}/unknown.topic.name/client",
-        "${metadata}/one.topic.error.unknown.topic/server" })
+        "${metadata}/two.topics.error.unknown.topic/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldRejectWhenTopicIsUnknown() throws Exception
     {


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/44

Adds more tests for compacted topic bootstrap, as described in the above PR.

The test for unrouting multiple topics is ignored because we do not currently have a mechanism for comparing the extension data from the unroute frame with the route extension data during execution of unroute, so the routes for all topics get removed from the route table by the first unroute command.