### PR TITLE
Progressive decoding of  fetch responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
-  - cd nukleus-kafka.spec
-  - git checkout streaming_decode
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkout bootstrap_more_tests
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - rm ~/.m2/settings.xml
   - git clone https://github.com/cmebarrow/nukleus-kafka.spec
   - cd nukleus-kafka.spec
-  - git checkout bootstrap_more_tests
+  - git checkout streaming_decode
   - mvn clean install -DskipTests
   - cd ..
 jdk:

--- a/README.md
+++ b/README.md
@@ -30,4 +30,12 @@ Each data frame represents the value of one Kafka message (a.k.a. record). The e
 Topics which are configured in Kafka with property "cleanup.policy" set to "compact" are treated specially, in the following ways:
 
 - A cache is maintained in order to enhance performance for subscriptions to a particular message key, and where possible only deliver the latest message for the key.
-- This cache is kept up to date all the time by doing proactive fetches, unless this turned off by setting system property "nukleus.kafka.topic.bootstrap.enabled" to "false".
+- This cache is kept up to date all the time by doing proactive fetches, unless this turned off by setting system property `nukleus.kafka.topic.bootstrap.enabled` to "false".
+
+### Configuration
+
+The following system properties are currently supported for configuration:
+
+- `nukleus.kafka.fetch.max.bytes` (integer, default 50 MiB): maximum value that will be specified as fetch.max.bytes in fetch requests made to Kafka.
+- `nukleus.kafka.fetch.partition.max.bytes` (integer, default 1 MiB): maximum size of a partition response. Should be set to the highest configured value for Kafka broker or topic configuration property "max.message.bytes".
+- `nukleus.kafka.topic.bootstrap.enabled` (boolean default true): caching of message keys and latest offsets is enabled for compacted topics to improve performance.

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.25</nukleus.plugin.version>
     <nukleus.version>0.18</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.40</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.41</nukleus.kafka.spec.version>
     <reaktor.version>0.41</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <k3po.version>3.0.0-alpha-88</k3po.version>
     <k3po.nukleus.ext.version>0.23</k3po.nukleus.ext.version>
 
-    <nukleus.plugin.version>0.28</nukleus.plugin.version>
+    <nukleus.plugin.version>0.30</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
     <nukleus.kafka.spec.version>0.55</nukleus.kafka.spec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.30</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.56</nukleus.kafka.spec.version>
     <reaktor.version>0.57</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.30</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.55</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.57</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
@@ -23,6 +23,8 @@ public class KafkaConfiguration extends Configuration
 
     public static final String FETCH_MAX_BYTES_PROPERTY = "nukleus.kafka.fetch.max.bytes";
 
+    // Maximum record batch size, corresponding to Kafka broker and topic configuration
+    // property "max.message.bytes"
     public static final String FETCH_PARTITION_MAX_BYTES_PROPERTY = "nukleus.kafka.fetch.partition.max.bytes";
 
     private static final boolean TOPIC_BOOTSTRAP_ENABLED_DEFAULT = true;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/function/StringIntShortConsumer.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/function/StringIntShortConsumer.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.function;
+
+@FunctionalInterface
+public interface StringIntShortConsumer
+{
+    void accept(String stringValue, int intValue, short shortValue);
+}

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/function/StringIntToLongFunction.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/function/StringIntToLongFunction.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.function;
+
+@FunctionalInterface
+public interface StringIntToLongFunction
+{
+    long apply(String stringValue, int intValue);
+}

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/FetchResponseDecoder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/FetchResponseDecoder.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import static java.util.Objects.requireNonNull;
+import static org.reaktivity.nukleus.buffer.BufferPool.NO_SLOT;
+
+import java.util.function.BiFunction;
+
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.reaktivity.nukleus.buffer.BufferPool;
+import org.reaktivity.nukleus.kafka.internal.function.StringIntToLongFunction;
+import org.reaktivity.nukleus.kafka.internal.types.OctetsFW;
+
+public class FetchResponseDecoder
+{
+    private final BiFunction<String, Integer, MessageDispatcher> getDispatcher;
+    private final StringIntToLongFunction getRequestedOffsetForPartition;
+    private final BufferPool bufferPool;
+    private final long streamId;
+
+    private DecoderState decoderState;
+    private int responseSize = -1;
+    private int responseBytesProcessed;
+    int slot = NO_SLOT;
+    int slotOffset;
+    int slotLimit;
+
+    FetchResponseDecoder(
+        BiFunction<String, Integer, MessageDispatcher> getDispatcher,
+        StringIntToLongFunction getRequestedOffsetForPartition,
+        BufferPool bufferPool,
+        long streamId)
+    {
+        this.getDispatcher = getDispatcher;
+        this.getRequestedOffsetForPartition = getRequestedOffsetForPartition;
+        this.bufferPool = requireNonNull(bufferPool);
+        this.streamId = streamId;
+        this.decoderState = this::decodeResponse;
+    }
+
+    public boolean decode(OctetsFW payload)
+    {
+        boolean responseComplete = false;
+        DirectBuffer buffer = payload.buffer();
+        int offset = payload.offset();
+        int limit = payload.limit();
+        if (slot != NO_SLOT)
+        {
+            buffer = appendToSlot(buffer, offset, limit);
+            offset = slotOffset;
+            limit = slotLimit;
+        }
+        int newOffset = decode(buffer, offset, limit);
+        responseBytesProcessed += limit - newOffset;
+        if (newOffset == limit && responseBytesProcessed == responseSize)
+        {
+            responseComplete = true;
+            free();
+        }
+        else
+        {
+            if (slot == NO_SLOT)
+            {
+                slot = bufferPool.acquire(streamId);
+                slotOffset = 0;
+                slotLimit = 0;
+                appendToSlot(buffer, newOffset, limit);
+            }
+        }
+        return responseComplete;
+    }
+
+    public void free()
+    {
+        if (slot != NO_SLOT)
+        {
+            bufferPool.release(slot);
+            slot = NO_SLOT;
+            slotOffset = 0;
+            slotLimit = 0;
+            responseSize = -1;
+            responseBytesProcessed = 0;
+        }
+    }
+
+    private DirectBuffer appendToSlot(DirectBuffer buffer, int offset, int limit)
+    {
+        final MutableDirectBuffer bufferSlot = bufferPool.buffer(slot);
+        final int bytesToCopy = limit -  offset;
+        bufferSlot.putBytes(slotOffset, buffer, offset, bytesToCopy);
+        slotLimit += bytesToCopy;
+        return bufferSlot;
+    }
+
+    private int decode(DirectBuffer buffer, int offset, int limit)
+    {
+        boolean decoderStateChanged = true;
+        while (offset < limit && decoderStateChanged)
+        {
+            DecoderState previous = decoderState;
+            offset = decoderState.decode(buffer, offset, limit);
+            decoderStateChanged = previous != decoderState;
+        }
+        return offset;
+    }
+
+    private int decodeResponse(
+        DirectBuffer buffer,
+        int offset,
+        int length)
+    {
+        return offset;
+    }
+
+    @FunctionalInterface
+    interface DecoderState
+    {
+        int decode(
+            DirectBuffer buffer,
+            int offset,
+            int length);
+    }
+}

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1073,7 +1073,7 @@ public final class NetworkConnectionPool
                     final int recordBatchSize = recordSet.recordBatchSize();
                     networkOffset = recordSet.limit() + recordBatchSize;
 
-                    long requestedOffset = getRueqestedOffset(topicName, partitionResponse.partitionId());
+                    long requestedOffset = getRequestedOffset(topicName, partitionResponse.partitionId());
 
                     if (topic != null && requestedOffset != NO_OFFSET)
                         // we still have subscribers

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -357,6 +357,7 @@ final class NetworkConnectionPool
         long networkReplyId;
 
         private MessageConsumer streamState;
+        private DecoderState decoderState;
 
         int networkSlot = NO_SLOT;
         int networkSlotOffset;
@@ -880,14 +881,14 @@ final class NetworkConnectionPool
                     if (topic != null)
                     {
                         int partitionResponseSize = networkOffset - partitionResponse.offset();
-                        long requiredOffset = getRequiredOffset(topicName, partitionResponse.partitionId());
-                        if (requiredOffset != NO_OFFSET)
+                        long requestedOffset = getRequestedOffset(topicName, partitionResponse.partitionId());
+                        if (requestedOffset != NO_OFFSET)
                         {
                             topic.onPartitionResponse(networkTraceId,
                                                       partitionResponse.buffer(),
                                                       partitionResponse.offset(),
                                                       partitionResponseSize,
-                                                      requiredOffset);
+                                                      requestedOffset);
                         }
                     }
 
@@ -895,7 +896,7 @@ final class NetworkConnectionPool
             }
         }
 
-        final long getRequiredOffset(String topicName, int partitionId)
+        final long getRequestedOffset(String topicName, int partitionId)
         {
             return requestedFetchOffsetsByTopic.get(topicName)[partitionId];
         }
@@ -1847,5 +1848,11 @@ final class NetworkConnectionPool
             value2.wrap(buffer);
             return value1.equals(value2);
         }
+    }
+
+    @FunctionalInterface
+    private interface DecoderState
+    {
+        int decode(DirectBuffer buffer, int offset, int length);
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -25,7 +25,6 @@ import static org.reaktivity.nukleus.kafka.internal.stream.KafkaErrors.NONE;
 import static org.reaktivity.nukleus.kafka.internal.stream.KafkaErrors.OFFSET_OUT_OF_RANGE;
 import static org.reaktivity.nukleus.kafka.internal.stream.KafkaErrors.UNKNOWN_TOPIC_OR_PARTITION;
 
-import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -185,7 +184,6 @@ public final class NetworkConnectionPool
     final ListOffsetsPartitionResponseFW listOffsetsPartitionResponseRO = new ListOffsetsPartitionResponseFW();
 
     final MutableDirectBuffer encodeBuffer;
-    final UnsafeBuffer temporaryBuffer;
 
     private final ClientStreamFactory clientStreamFactory;
     private final String networkName;
@@ -222,7 +220,6 @@ public final class NetworkConnectionPool
         this.topicsByName = new LinkedHashMap<>();
         this.topicMetadataByName = new HashMap<>();
         this.detachersById = new Int2ObjectHashMap<>();
-        this.temporaryBuffer = new UnsafeBuffer(ByteBuffer.allocateDirect(fetchPartitionMaxBytes));
 
         // TODO: remove this and use multiple data frames to deliver large messages
         this.maximumMessageSize = bufferPool.slotCapacity() > MAX_PADDING ?
@@ -793,7 +790,6 @@ public final class NetworkConnectionPool
                     this::getRequestedOffset,
                     this::handlePartitionResponseError,
                     localDecodeBuffer,
-                    temporaryBuffer,
                     maximumMessageSize);
         }
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -357,7 +357,6 @@ final class NetworkConnectionPool
         long networkReplyId;
 
         private MessageConsumer streamState;
-        private DecoderState decoderState;
 
         int networkSlot = NO_SLOT;
         int networkSlotOffset;
@@ -1848,11 +1847,5 @@ final class NetworkConnectionPool
             value2.wrap(buffer);
             return value1.equals(value2);
         }
-    }
-
-    @FunctionalInterface
-    private interface DecoderState
-    {
-        int decode(DirectBuffer buffer, int offset, int length);
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -534,7 +534,7 @@ final class NetworkConnectionPool
         }
 
 
-        private void handleData(
+        void handleData(
             DataFW data)
         {
             final OctetsFW payload = data.payload();

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ResponseDecoder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ResponseDecoder.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import org.reaktivity.nukleus.kafka.internal.types.OctetsFW;
+
+interface ResponseDecoder
+{
+
+    /**
+     * @param payload to decode
+     * @return true if the response is complete, false if more data is needed
+     */
+    boolean decode(OctetsFW data);
+
+    void free();
+
+}

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ResponseDecoder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ResponseDecoder.java
@@ -23,12 +23,13 @@ interface ResponseDecoder
     /**
      * @param payload to decode
      * @return A negative value if the response is incomplete, else the number of bytes
-     *         remaining following the first complete response
+     *         remaining following the first complete response (this will always be 0
+     *         unless pipelined requests were issued)
      */
     int decode(
         OctetsFW data,
         long traceId);
 
-    void free();
+    void reinitialize();
 
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ResponseDecoder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ResponseDecoder.java
@@ -24,7 +24,8 @@ interface ResponseDecoder
      * @param payload to decode
      * @return true if the response is complete, false if more data is needed
      */
-    boolean decode(OctetsFW data);
+    boolean decode(OctetsFW data,
+                   long traceId);
 
     void free();
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ResponseDecoder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ResponseDecoder.java
@@ -22,10 +22,12 @@ interface ResponseDecoder
 
     /**
      * @param payload to decode
-     * @return true if the response is complete, false if more data is needed
+     * @return A negative value if the response is incomplete, else the number of bytes
+     *         remaining following the first complete response
      */
-    boolean decode(OctetsFW data,
-                   long traceId);
+    int decode(
+        OctetsFW data,
+        long traceId);
 
     void free();
 

--- a/src/main/reaktivity/protocol.idl
+++ b/src/main/reaktivity/protocol.idl
@@ -130,7 +130,7 @@ scope protocol
 
             struct RecordSet
             {
-              int32 recordBatchSize;
+              int32 recordSetSize;
             }
 
             struct RecordBatch

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -558,7 +558,7 @@ public class FetchIT
     @Specification({
         "${route}/client/controller",
         "${client}/zero.offset.message/client",
-        "${server}/zero.offset.message.zero.length.record.batch.is.skipped/server"})
+        "${server}/zero.length.record.batch/server"})
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
         "messageOffset 2"
@@ -751,7 +751,7 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/record.batch.ends.with.truncated.record/client",
+        "${client}/record.batch.truncated/client",
         "${server}/record.batch.ends.with.truncated.record/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveMessageWithTruncatedRecord() throws Exception
@@ -762,7 +762,18 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/record.batch.ends.with.truncated.record/client",
+        "${client}/record.batch.truncated/client",
+        "${server}/record.batch.truncated/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveMessageRecordSetEndsWithTruncatedRecordBatch() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/record.batch.truncated/client",
         "${server}/record.batch.truncated.at.record.boundary/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveMessageRecordBatchTruncatedOnRecordBoundary() throws Exception

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -762,6 +762,17 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/record.batch.ends.with.truncated.record/client",
+        "${server}/record.batch.truncated.at.record.boundary/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveMessageRecordBatchTruncatedOnRecordBoundary() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/zero.offset.message/client",
         "${server}/live.fetch.reset.reconnect.and.message/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -77,7 +77,7 @@ public class FetchLimitsIT
     @Specification({
         "${route}/client/controller",
         "${client}/zero.offset.large.message/client",
-        "${server}/zero.offset.message.response.exceeds.256.bytes/server"})
+        "${server}/zero.offset.large.response/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldHandleFetchResponseWithSizeExceedingMaxRecordBatchSize() throws Exception
     {
@@ -90,7 +90,7 @@ public class FetchLimitsIT
     @Specification({
         "${route}/client/controller",
         "${client}/zero.offset.large.message/client",
-        "${server}/zero.offset.first.record.batch.exceeds.336.bytes/server"})
+        "${server}/zero.offset.first.record.batch.large/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldSkipRecordBatchExceedingMaxRecordBatchSize() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -76,10 +76,10 @@ public class FetchLimitsIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/zero.offset.large.message/client",
+        "${client}/zero.offset.large.response/client",
         "${server}/zero.offset.large.response/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldHandleFetchResponseWithSizeExceedingMaxRecordBatchSize() throws Exception
+    public void shouldHandleLargeFetchResponseProvidedEachRecordBatchLessThanMaxPartitionBytes() throws Exception
     {
         k3po.start();
         k3po.notifyBarrier("WRITE_FETCH_RESPONSE");

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -51,7 +51,8 @@ public class FetchLimitsIT
         .clean()
         .configure(KafkaConfiguration.TOPIC_BOOTSTRAP_ENABLED, "false")
         .configure(ReaktorConfiguration.BUFFER_SLOT_CAPACITY_PROPERTY, 256)
-        .configure(KafkaConfiguration.FETCH_MAX_BYTES_PROPERTY, 256);
+        .configure(KafkaConfiguration.FETCH_MAX_BYTES_PROPERTY, 256)
+        .configure(KafkaConfiguration.FETCH_PARTITION_MAX_BYTES_PROPERTY, 336);
 
     @Rule
     public final TestRule chain = outerRule(reaktor).around(k3po).around(timeout);
@@ -62,21 +63,36 @@ public class FetchLimitsIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/zero.offset.messages.multiple.partitions.max.bytes.256/client",
-        "${server}/zero.offset.messages.multiple.partitions.max.bytes.256/server" })
+        "${client}/zero.offset.large.message/client",
+        "${server}/zero.offset.messages.first.exceeds.256.bytes/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldReceiveMessagesFromMultiplePartitionsWhenResponseSizeEqualsSlotSize() throws Exception
+    public void shouldSkipMessageExceedingMaximumSupportedMessageSize() throws Exception
     {
+        k3po.start();
+        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
         k3po.finish();
     }
 
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/zero.offset.messages.response.exceeds.requested.256.bytes/client",
-        "${server}/zero.offset.messages.response.exceeds.requested.256.bytes/server" })
+        "${client}/zero.offset.large.message/client",
+        "${server}/zero.offset.message.response.exceeds.256.bytes/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldHandleFetchResponsesWithSizeExceedingSlotCapacity() throws Exception
+    public void shouldHandleFetchResponseWithSizeExceedingMaxRecordBatchSize() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/zero.offset.large.message/client",
+        "${server}/zero.offset.first.record.batch.exceeds.336.bytes/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldSkipRecordBatchExceedingMaxRecordBatchSize() throws Exception
     {
         k3po.start();
         k3po.notifyBarrier("WRITE_FETCH_RESPONSE");


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/46.

Each broker connection now uses a single buffer for decoding fetch responses, of size equal to the value of configuration property `nukleus.kafka.fetch.partition.max.bytes` (default 1 MiB). This should be set to the the maximum possible size of a record batch, which is the maximum value of the `max.message.bytes` configuration property as set on the Kafka broker or any of the topics in use.

Fetch responses are progressively decoded, allowing processing of arbitrarily large fetch responses. The record set contained in each partition response is read entirely into the decode buffer before dispatching the contained messages (records), to avoid the need for allocating separate buffers for message keys headers and values.  Partition responses whose record set size exceeds `nukleus.kafka.fetch.partition.max.bytes` are  skipped (test case zero.offset.first.record.batch.large).