### PR TITLE
Fixed DefaultMemoryManager to avoid returning the root node from aqui…

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManager.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManager.java
@@ -101,10 +101,11 @@ public class DefaultMemoryManager implements MemoryManager
             }
         }
 
-        if (node.flag(FULL))
+        if (node.flag(FULL) || node.flag(SPLIT))
         {
             return -1;
         }
+        assert node.order() == allocationOrder;
 
         node.set(FULL);
 


### PR DESCRIPTION
…re when there's not enough space for the requested capacity.