### PR TITLE
Delayed route bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkout delayed_route_bootstrap
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Topics which are configured in Kafka with property "cleanup.policy" set to "comp
 
 - A cache of message offsets is maintained in order to enhance performance for subscriptions to a particular message key, and where possible only deliver the latest message for the key.
 - This cache is kept up to date all the time by doing proactive fetches, unless this turned off by setting system property `nukleus.kafka.topic.bootstrap.enabled` to "false".
-- A message cache  with configurable size is used to store the latest message for each key.  This allows most subscriptions to a particular message key or to the whole topic to be satisfied without accessing the Kafka broker, assuming the cache is large enough to fit the latest message for each key, 
+- A message cache with configurable size is used to store the latest message for each key.  This allows most subscriptions to a particular message key or to the whole topic to be satisfied without accessing the Kafka broker, assuming the cache is large enough to fit the latest message for each key, 
+- Messages on compacted topics are cached during bootstrap. This is limited to topics whose routes include header conditions, unless system property `nukleus.kafka.message.cache.proactive` is set to "true" to force caching for all compacted topics.
 
 ### Configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.30</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.60</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.57</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
@@ -23,6 +23,10 @@ public class KafkaConfiguration extends Configuration
 
     public static final String FETCH_MAX_BYTES_PROPERTY = "nukleus.kafka.fetch.max.bytes";
 
+    // "headers": cache messages during bootstrap only for topics with route header conditions
+    // "all": cache messages during bootstrap for all topics
+    public static final String MESSAGE_CACHE_PROACTIVE_PROPERTY = "nukleus.kafka.message.cache.proactive";
+
     // Maximum record batch size, corresponding to Kafka broker and topic configuration
     // property "max.message.bytes"
     public static final String FETCH_PARTITION_MAX_BYTES_PROPERTY = "nukleus.kafka.fetch.partition.max.bytes";
@@ -40,6 +44,8 @@ public class KafkaConfiguration extends Configuration
     public static final int MESSAGE_CACHE_CAPACITY_DEFAULT = 128 * 1024 * 1024;
 
     public static final int MESSAGE_CACHE_BLOCK_CAPACITY_DEFAULT = 1024;
+
+    public static final boolean DEFAULT_MESSAGE_CACHE_PROACTIVE = false;
 
     public KafkaConfiguration(
         Configuration config)
@@ -70,6 +76,11 @@ public class KafkaConfiguration extends Configuration
     public int messageCacheBlockCapacity()
     {
         return getInteger(MESSAGE_CACHE_BLOCK_CAPACITY_PROPERTY, MESSAGE_CACHE_BLOCK_CAPACITY_DEFAULT);
+    }
+
+    public boolean messageCacheBootstrapAll()
+    {
+        return getBoolean(MESSAGE_CACHE_PROACTIVE_PROPERTY, DEFAULT_MESSAGE_CACHE_PROACTIVE);
     }
 
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
@@ -78,7 +78,7 @@ public class KafkaConfiguration extends Configuration
         return getInteger(MESSAGE_CACHE_BLOCK_CAPACITY_PROPERTY, MESSAGE_CACHE_BLOCK_CAPACITY_DEFAULT);
     }
 
-    public boolean messageCacheBootstrapAll()
+    public boolean messageCacheProactive()
     {
         return getBoolean(MESSAGE_CACHE_PROACTIVE_PROPERTY, DEFAULT_MESSAGE_CACHE_PROACTIVE);
     }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
@@ -49,7 +49,7 @@ import org.reaktivity.nukleus.kafka.internal.types.control.RouteFW;
 
 public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
 {
-    private static final String MESSAGE_CACHE_BUFFER_ACQUIRES = "message.cache.buffer.acquires";
+    public static final String MESSAGE_CACHE_BUFFER_ACQUIRES = "message.cache.buffer.acquires";
     private static final String MESSAGE_CACHE_BUFFER_RELEASES = "message.cache.buffer.releases";
 
     private static final MemoryManager OUT_OF_SPACE_MEMORY_MANAGER = new MemoryManager()
@@ -206,13 +206,11 @@ public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
                 ListFW<KafkaHeaderFW> headersCopy = new ListFW<KafkaHeaderFW>(new KafkaHeaderFW());
                 headersCopy.wrap(headers.buffer(), headers.offset(), headers.limit());
 
-                connectionPool.addRoute(topicName, headersCopy);
+                if (kafkaConfig.topicBootstrapEnabled())
+                {
+                    connectionPool.addRoute(topicName, headersCopy, this::doBootstrapTopic);
+                }
             }
-        }
-        if (kafkaConfig.topicBootstrapEnabled())
-        {
-            connectionPools.forEach((networkName, poolsByRef) ->
-                poolsByRef.forEach((ref, pool) -> pool.doBootstrap(this::doBootstrapTopic)));
         }
     }
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/CompactedPartitionIndex.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/CompactedPartitionIndex.java
@@ -75,7 +75,8 @@ public class CompactedPartitionIndex implements PartitionIndex
         long traceId,
         DirectBuffer key,
         HeadersFW headers,
-        DirectBuffer value)
+        DirectBuffer value,
+        boolean cacheNewMessages)
     {
         buffer.wrap(key, 0, key.capacity());
         EntryImpl entry = offsetsByKey.get(buffer);
@@ -98,7 +99,10 @@ public class CompactedPartitionIndex implements PartitionIndex
                 entry.offset = messageStartOffset;
             }
             entries.add(entry);
-            cacheMessage(entry, timestamp, traceId, key, headers, value);
+            if (cacheNewMessages)
+            {
+                cacheMessage(entry, timestamp, traceId, key, headers, value);
+            }
         }
         else if (requestOffset > validToOffset)
         {
@@ -110,12 +114,15 @@ public class CompactedPartitionIndex implements PartitionIndex
                 keyCopy.putBytes(0,  key, 0, key.capacity());
                 entry = new EntryImpl(messageStartOffset, NO_MESSAGE, entries.size());
                 offsetsByKey.put(keyCopy, entry);
-                cacheMessage(entry, timestamp, traceId, key, headers, value);
+                if (cacheNewMessages)
+                {
+                    cacheMessage(entry, timestamp, traceId, key, headers, value);
+                }
             }
         }
-        else if (messageCache.get(entry.message, messageRO) == null)
+        else if (entry.offset == messageStartOffset && messageCache.get(entry.message, messageRO) == null)
         {
-            // historical message which was previously evicted due to lack of space, re-cache it
+            // We already saw this offset. Either we didn't cache the message or it was evicted due to lack of space.
             entry.message = messageCache.replace(entry.message, timestamp, traceId, key, headers, value);
         }
     }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/DefaultPartitionIndex.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/DefaultPartitionIndex.java
@@ -35,7 +35,8 @@ public class DefaultPartitionIndex implements PartitionIndex
         long traceId,
         DirectBuffer key,
         HeadersFW headers,
-        DirectBuffer value)
+        DirectBuffer value,
+        boolean cacheNewMessages)
     {
         // no-op
     }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/PartitionIndex.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/PartitionIndex.java
@@ -39,7 +39,8 @@ public interface PartitionIndex
         long traceId,
         DirectBuffer key,
         HeadersFW headers,
-        DirectBuffer value);
+        DirectBuffer value,
+        boolean cacheNewMessages);
 
     Iterator<Entry> entries(
         long requestOffset);

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -118,6 +118,7 @@ public final class ClientStreamFactory implements StreamFactory
     private final Map<String, Long2ObjectHashMap<NetworkConnectionPool>> connectionPools;
     private final int fetchMaxBytes;
     private final int fetchPartitionMaxBytes;
+    private final boolean forceProactiveMessageCache;
 
     public ClientStreamFactory(
         KafkaConfiguration config,
@@ -134,6 +135,7 @@ public final class ClientStreamFactory implements StreamFactory
     {
         this.fetchMaxBytes = config.fetchMaxBytes();
         this.fetchPartitionMaxBytes = config.fetchPartitionMaxBytes();
+        this.forceProactiveMessageCache = config.messageCacheBootstrapAll();
         this.router = requireNonNull(router);
         this.writeBuffer = requireNonNull(writeBuffer);
         this.bufferPool = requireNonNull(bufferPool);
@@ -146,7 +148,8 @@ public final class ClientStreamFactory implements StreamFactory
         groupBudget = new Long2LongHashMap(-1);
         groupMembers = new Long2LongHashMap(-1);
         setConnectionPoolFactory.accept((networkName, ref) ->
-            new NetworkConnectionPool(this, networkName, ref, fetchMaxBytes, fetchPartitionMaxBytes, bufferPool, messageCache));
+            new NetworkConnectionPool(this, networkName, ref, fetchMaxBytes, fetchPartitionMaxBytes, bufferPool,
+                    messageCache, forceProactiveMessageCache));
     }
 
     @Override
@@ -203,7 +206,7 @@ public final class ClientStreamFactory implements StreamFactory
 
                 NetworkConnectionPool connectionPool = connectionPoolsByRef.computeIfAbsent(networkRef,
                         ref -> new NetworkConnectionPool(this, networkName, ref, fetchMaxBytes, fetchPartitionMaxBytes,
-                                bufferPool, messageCache));
+                                bufferPool, messageCache, forceProactiveMessageCache));
 
                 newStream = new ClientAcceptStream(applicationThrottle, applicationId, connectionPool)::handleStream;
             }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -136,7 +136,7 @@ public final class ClientStreamFactory implements StreamFactory
     {
         this.fetchMaxBytes = config.fetchMaxBytes();
         this.fetchPartitionMaxBytes = config.fetchPartitionMaxBytes();
-        this.forceProactiveMessageCache = config.messageCacheBootstrapAll();
+        this.forceProactiveMessageCache = config.messageCacheProactive();
         this.router = requireNonNull(router);
         this.writeBuffer = requireNonNull(writeBuffer);
         this.bufferPool = requireNonNull(bufferPool);

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/DecoderMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/DecoderMessageDispatcher.java
@@ -24,6 +24,7 @@ public interface DecoderMessageDispatcher
         int partition,
         long requestOffset,
         long messageOffset,
+        long highWatermark,
         DirectBuffer key,
         HeadersFW headers,
         long timestamp,

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/FetchResponseDecoder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/FetchResponseDecoder.java
@@ -565,7 +565,7 @@ public class FetchResponseDecoder implements ResponseDecoder
                 else
                 {
                     headers.wrap(buffer, headersOffset, headersLimit);
-                    messageDispatcher.dispatch(partition, requestedOffset, nextFetchAt,
+                    messageDispatcher.dispatch(partition, requestedOffset, nextFetchAt, highWatermark,
                             key, headers, timestamp, traceId, value);
                 }
             }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapCachingIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapCachingIT.java
@@ -27,6 +27,8 @@ import org.kaazing.k3po.junit.annotation.ScriptProperty;
 import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 import org.reaktivity.nukleus.kafka.internal.KafkaConfiguration;
+import org.reaktivity.nukleus.kafka.internal.KafkaController;
+import org.reaktivity.nukleus.kafka.internal.KafkaNukleusFactorySpi;
 import org.reaktivity.reaktor.test.ReaktorRule;
 
 public class BootstrapCachingIT
@@ -43,6 +45,7 @@ public class BootstrapCachingIT
 
     private final ReaktorRule reaktor = new ReaktorRule()
         .nukleus("kafka"::equals)
+        .controller(name -> name.equals("kafka"))
         .directory("target/nukleus-itests")
         .commandBufferCapacity(1024)
         .responseBufferCapacity(1024)
@@ -65,7 +68,18 @@ public class BootstrapCachingIT
         k3po.start();
         k3po.awaitBarrier("ROUTED_CLIENT");
         k3po.awaitBarrier("FETCH_REQUEST_RECEIVED");
-        Thread.sleep(1000); // ensure bootstrap is complete before client attaches
+
+        // Wait for both routes to be added to the caching filter
+        Thread.sleep(500);
+
+        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
+
+        // ensure bootstrap is complete before client attaches
+        while (reaktor.controller(KafkaController.class).count(KafkaNukleusFactorySpi.MESSAGE_CACHE_BUFFER_ACQUIRES) < 2L)
+        {
+            Thread.sleep(100);
+        }
+
         k3po.notifyBarrier("CONNECT_CLIENT_ONE");
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
@@ -221,13 +221,14 @@ public class CachingFetchIT
         "${client}/compacted.historical.uses.cached.key.then.live/client",
         "${server}/compacted.historical.uses.cached.key.then.live.no.historical/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    // TODO: Fix failure
     public void shouldReceiveCompactedMessageUsingCachedKeyOffsetThenCatchUpToLiveStream() throws Exception
     {
         k3po.start();
         k3po.awaitBarrier("CLIENT_ONE_RECEIVED_FIRST_MESSAGE");
         k3po.notifyBarrier("CONNECT_CLIENT_TWO");
         k3po.awaitBarrier("CLIENT_TWO_RECEIVED_FIRST_MESSAGE");
-        k3po.notifyBarrier("DELIVER_SECOND_LIVE_RESPONSE");
+        k3po.notifyBarrier("DELIVER_FINAL_LIVE_RESPONSE");
         k3po.finish();
     }
 
@@ -360,10 +361,10 @@ public class CachingFetchIT
     @Specification({
         "${route}/client/controller",
         "${client}/compacted.messages.one.per.key/client",
-        "${server}/compacted.messages/server"})
+        "${server}/compacted.messages.live/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     // Behavior is different with message cache: better compaction, guaranteed only one message per key
-    public void shouldReceiveCompactedHistoricalMessagesFromCache() throws Exception
+    public void shouldReceiveCompactedHistoricalMessagesFromCacheWhenOriginallyReceivedAsLiveMessages() throws Exception
     {
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchLimitsIT.java
@@ -76,6 +76,7 @@ public class CachingFetchLimitsIT
         k3po.start();
         k3po.awaitBarrier("ROUTED_CLIENT");
         k3po.notifyBarrier("CONNECT_CLIENT_ONE");
+        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
         k3po.finish();
     }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingProactiveFetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingProactiveFetchIT.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.k3po.junit.annotation.ScriptProperty;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.reaktivity.nukleus.kafka.internal.KafkaConfiguration;
+import org.reaktivity.reaktor.test.ReaktorRule;
+
+public class CachingProactiveFetchIT
+{
+    private final K3poRule k3po = new K3poRule()
+            .addScriptRoot("route", "org/reaktivity/specification/nukleus/kafka/control/route.ext")
+            .addScriptRoot("routeAnyTopic", "org/reaktivity/specification/nukleus/kafka/control/route")
+            .addScriptRoot("control", "org/reaktivity/specification/nukleus/kafka/control")
+            .addScriptRoot("server", "org/reaktivity/specification/kafka/fetch.v5")
+            .addScriptRoot("metadata", "org/reaktivity/specification/kafka/metadata.v5")
+            .addScriptRoot("client", "org/reaktivity/specification/nukleus/kafka/streams/fetch");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+
+    private final ReaktorRule reaktor = new ReaktorRule()
+        .nukleus("kafka"::equals)
+        .directory("target/nukleus-itests")
+        .commandBufferCapacity(1024)
+        .responseBufferCapacity(1024)
+        .counterValuesBufferCapacity(1024)
+        .configure(KafkaConfiguration.TOPIC_BOOTSTRAP_ENABLED, "false")
+        .configure(KafkaConfiguration.MESSAGE_CACHE_PROACTIVE_PROPERTY, "true")
+        .configure(KafkaConfiguration.MESSAGE_CACHE_CAPACITY_PROPERTY, Integer.toString(1024 * 1024))
+        .clean();
+
+    @Rule
+    public final TestRule chain = outerRule(reaktor).around(k3po).around(timeout);
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/compacted.messages.one.per.key/client",
+        "${server}/compacted.messages/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    // Behavior is different with message cache: better compaction, guaranteed only one message per key
+    public void shouldReceiveCompactedHistoricalMessagesFromCacheWhenProactiveMessageCachingIsEnabled() throws Exception
+    {
+        k3po.finish();
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcherTest.java
@@ -107,10 +107,10 @@ public final class TopicMessageDispatcherTest
                         with(headers.headerSupplier()), with(timestamp), with(traceId), with((DirectBuffer) null));
                 will(returnValue(FLAGS_DELIVERED));
                 oneOf(partitionIndex2).add(with(10L), with(11L), with(timestamp), with(traceId),
-                        with((DirectBuffer) null), with(headers), with((DirectBuffer) null));
+                        with((DirectBuffer) null), with(headers), with((DirectBuffer) null), with(false));
             }
         });
-        assertEquals(FLAGS_DELIVERED, dispatcher.dispatch(1, 10L, 12L, null, headers, timestamp, traceId, null));
+        assertEquals(FLAGS_DELIVERED, dispatcher.dispatch(1, 10L, 12L, 999L, null, headers, timestamp, traceId, null));
     }
 
 
@@ -142,7 +142,7 @@ public final class TopicMessageDispatcherTest
                 oneOf(partitionIndex1).nextOffset();
                 will(returnValue(0L));
                 oneOf(partitionIndex1).add(with(10L), with(11L), with(timestamp1), with(traceId),
-                        with(bufferMatching("key1")), with(headers), with((DirectBuffer) null));
+                        with(bufferMatching("key1")), with(headers), with((DirectBuffer) null), with(false));
 
                 oneOf(child3).dispatch(with(1), with(10L), with(13L), with(bufferMatching("key2")),
                         with(headers.headerSupplier()), with(timestamp2), with(traceId), with((DirectBuffer) null));
@@ -151,17 +151,17 @@ public final class TopicMessageDispatcherTest
                 oneOf(partitionIndex2).nextOffset();
                 will(returnValue(0L));
                 oneOf(partitionIndex2).add(with(10L), with(12L), with(timestamp1), with(traceId),
-                        with(bufferMatching("key2")), with(headers), with((DirectBuffer) null));
+                        with(bufferMatching("key2")), with(headers), with((DirectBuffer) null), with(false));
             }
         });
         assertEquals(FLAGS_DELIVERED,
-                dispatcher.dispatch(0, 10L, 12L, asBuffer("key1"), headers, timestamp1, traceId, null));
+                dispatcher.dispatch(0, 10L, 12L, 999L, asBuffer("key1"), headers, timestamp1, traceId, null));
         assertEquals(FLAGS_DELIVERED,
-                dispatcher.dispatch(1, 10L, 13L, asBuffer("key2"), headers, timestamp2, traceId, null));
+                dispatcher.dispatch(1, 10L, 13L, 999L, asBuffer("key2"), headers, timestamp2, traceId, null));
     }
 
     @Test
-    public void shouldCacheButNotDispatchNonMatchingKey()
+    public void shouldCacheOffsetButNotDispatchNonMatchingKey()
     {
         MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
         MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
@@ -184,11 +184,74 @@ public final class TopicMessageDispatcherTest
                         with(headers.headerSupplier()), with(timestamp), with(0L), with((DirectBuffer) null));
                 will(returnValue(MessageDispatcher.FLAGS_MATCHED));
                 oneOf(partitionIndex2).add(with(10L), with(11L), with(timestamp), with(0L),
-                        with(bufferMatching("key2")), with(headers), with((DirectBuffer) null));
+                        with(bufferMatching("key2")), with(headers), with((DirectBuffer) null), with(false));
             }
         });
         assertEquals(MessageDispatcher.FLAGS_MATCHED,
-                dispatcher.dispatch(1, 10L, 12L, asBuffer("key2"), headers, timestamp, 0L, null));
+                dispatcher.dispatch(1, 10L, 12L, 999L, asBuffer("key2"), headers, timestamp, 0L, null));
+    }
+
+    @Test
+    public void shouldCacheOffsetAndMessageWhenProactiveMessageCachingEnabled()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        MessageDispatcher routeMatcher = context.mock(MessageDispatcher.class, "routeMatcher");
+        dispatcher.add(asOctets("key1"), 1, emptyHeaders, child1);
+        dispatcher.add(asOctets("key1"), 1, emptyHeaders, child2);
+        dispatcher.add(null, 1, emptyHeaders, routeMatcher);
+
+        HeadersFW headers = emptyHeaders();
+
+        final long timestamp = System.currentTimeMillis() - 123;
+
+        context.checking(new Expectations()
+        {
+            {
+                oneOf(partitionIndex2).getEntry(with(10L), with(asOctets("key2")));
+                oneOf(partitionIndex2).nextOffset();
+                will(returnValue(0L));
+                oneOf(routeMatcher).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key2")),
+                        with(headers.headerSupplier()), with(timestamp), with(0L), with((DirectBuffer) null));
+                will(returnValue(MessageDispatcher.FLAGS_MATCHED));
+                oneOf(partitionIndex2).add(with(10L), with(11L), with(timestamp), with(0L),
+                        with(bufferMatching("key2")), with(headers), with((DirectBuffer) null), with(true));
+            }
+        });
+        dispatcher.enableProactiveMessageCaching();
+        assertEquals(MessageDispatcher.FLAGS_MATCHED,
+                dispatcher.dispatch(1, 10L, 12L, 999L, asBuffer("key2"), headers, timestamp, 0L, null));
+    }
+
+    @Test
+    public void shouldCacheOffsetAndMessageWhenLCaughtUpToLiveStream()
+    {
+        MessageDispatcher child1 = context.mock(MessageDispatcher.class, "child1");
+        MessageDispatcher child2 = context.mock(MessageDispatcher.class, "child2");
+        MessageDispatcher routeMatcher = context.mock(MessageDispatcher.class, "routeMatcher");
+        dispatcher.add(asOctets("key1"), 1, emptyHeaders, child1);
+        dispatcher.add(asOctets("key1"), 1, emptyHeaders, child2);
+        dispatcher.add(null, 1, emptyHeaders, routeMatcher);
+
+        HeadersFW headers = emptyHeaders();
+
+        final long timestamp = System.currentTimeMillis() - 123;
+
+        context.checking(new Expectations()
+        {
+            {
+                oneOf(partitionIndex2).getEntry(with(10L), with(asOctets("key2")));
+                oneOf(partitionIndex2).nextOffset();
+                will(returnValue(0L));
+                oneOf(routeMatcher).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key2")),
+                        with(headers.headerSupplier()), with(timestamp), with(0L), with((DirectBuffer) null));
+                will(returnValue(MessageDispatcher.FLAGS_MATCHED));
+                oneOf(partitionIndex2).add(with(10L), with(11L), with(timestamp), with(0L),
+                        with(bufferMatching("key2")), with(headers), with((DirectBuffer) null), with(true));
+            }
+        });
+        assertEquals(MessageDispatcher.FLAGS_MATCHED,
+                dispatcher.dispatch(1, 10L, 12L, 12L, asBuffer("key2"), headers, timestamp, 0L, null));
     }
 
     @Test


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/51

Fixes a bug with the handling of routes which, depending on timing, could cause messages not to be cached when they should be when there are multiple routes with different header conditions on the same topic.

Also restricts caching of messages during bootstrap to compacted topics whose routes include header conditions.   Caching of all messages on compacted topics during bootstrap can  be turned back on by setting system property `nukleus.kafka.message.cache.proactive` to "true"