### PR TITLE
Added support for large messages delivered in multiple DATA frames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
-  - cd nukleus-kafka.spec
-  - git checkout large_messages
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkout large_messages
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.30</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.60</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.57</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <k3po.version>3.0.0-alpha-96</k3po.version>
     <k3po.nukleus.ext.version>0.25</k3po.nukleus.ext.version>
 
-    <nukleus.plugin.version>0.31</nukleus.plugin.version>
+    <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
     <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.64</nukleus.kafka.spec.version>
     <reaktor.version>0.57</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -595,10 +595,22 @@ public final class ClientStreamFactory implements StreamFactory
                     pendingMessageOffset = messageStartOffset;
                     messagePending = true;
                     result &= MessageDispatcher.FLAGS_DELIVERED;
+                    if (bytesToWrite < payloadLength)
+                    {
+                        outOfWindow = true;
+                    }
                 }
                 else
                 {
                     outOfWindow = true;
+                }
+                if (outOfWindow)
+                {
+                    result |= MessageDispatcher.FLAGS_BLOCKED;
+                }
+                else
+                {
+                    result |= MessageDispatcher.FLAGS_DELIVERED;
                 }
             }
             return result;
@@ -619,8 +631,7 @@ public final class ClientStreamFactory implements StreamFactory
                 startOffset = fetchOffsets.get(partition);
                 endOffset = nextFetchOffset;
             }
-            else if (requestOffset <= startOffset
-                    && !outOfWindow && fragmentedMessageOffset == UNSET)
+            else if (requestOffset <= startOffset && !outOfWindow)
             {
                 // We didn't skip or do partial write of any messages due to lack of window, advance to highest offset
                 endOffset = nextFetchOffset;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -940,7 +940,8 @@ public final class ClientStreamFactory implements StreamFactory
         @Override
         public void applicationReplyBudget(int budget)
         {
-            applicationReplyBudget = budget;        }
+            applicationReplyBudget = budget;
+        }
 
         @Override
         public void decApplicationReplyBudget(int data)

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -580,7 +580,7 @@ public final class ClientStreamFactory implements StreamFactory
                 final int payloadLength = value == null ? 0 : value.capacity() - fragmentedMessageBytesWritten;
                 int applicationReplyBudget = budget.applicationReplyBudget();
                 int writeableBytes = applicationReplyBudget - applicationReplyPadding;
-                if (writeableBytes > 0 || payloadLength == 0)
+                if (writeableBytes > 0)
                 {
                     int bytesToWrite = Math.min(payloadLength, writeableBytes);
                     budget.decApplicationReplyBudget(bytesToWrite + applicationReplyPadding);

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -670,6 +670,7 @@ public final class ClientStreamFactory implements StreamFactory
                     fragmentedMessageBytesWritten += (pendingMessageValueLimit - pendingMessageValueOffset);
                     fragmentedMessageOffset = pendingMessageOffset;
                     progressEndOffset = pendingMessageOffset;
+                    this.fetchOffsets.put(partition, pendingMessageOffset);
                 }
             }
         }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -18,6 +18,8 @@ package org.reaktivity.nukleus.kafka.internal.stream;
 import static java.util.Objects.requireNonNull;
 import static org.reaktivity.nukleus.kafka.internal.util.BufferUtil.EMPTY_BYTE_ARRAY;
 import static org.reaktivity.nukleus.kafka.internal.util.BufferUtil.wrap;
+import static org.reaktivity.nukleus.kafka.internal.util.Flags.FIN;
+import static org.reaktivity.nukleus.kafka.internal.util.Flags.INIT;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -60,6 +62,7 @@ import org.reaktivity.nukleus.kafka.internal.types.KafkaHeaderFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.ResetFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.WindowFW;
 import org.reaktivity.nukleus.kafka.internal.util.BufferUtil;
+import org.reaktivity.nukleus.kafka.internal.util.Flags;
 import org.reaktivity.nukleus.route.RouteManager;
 import org.reaktivity.nukleus.stream.StreamFactory;
 
@@ -397,20 +400,47 @@ public final class ClientStreamFactory implements StreamFactory
         final long targetId,
         final long traceId,
         final int padding,
+        final byte flags,
         final DirectBuffer messageKey,
         final long timestamp,
         final DirectBuffer messageValue,
+        final int messageValueLimit,
         final Long2LongHashMap fetchOffsets)
     {
         OctetsFW key = messageKey == null ? null : messageKeyRO.wrap(messageKey, 0, messageKey.capacity());
-        OctetsFW value = messageValue == null ? null : messageValueRO.wrap(messageValue, 0, messageValue.capacity());
+        OctetsFW value = messageValue == null ? null : messageValueRO.wrap(messageValue, 0, messageValueLimit);
         final DataFW data = dataRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                 .streamId(targetId)
                 .trace(traceId)
+                .flags(flags)
                 .groupId(0)
                 .padding(padding)
                 .payload(value)
                 .extension(e -> e.set(visitKafkaDataEx(timestamp, fetchOffsets, key)))
+                .build();
+
+        target.accept(data.typeId(), data.buffer(), data.offset(), data.sizeof());
+    }
+
+    private void doKafkaDataContinuation(
+        final MessageConsumer target,
+        final long targetId,
+        final long traceId,
+        final int padding,
+        final byte flags,
+        final DirectBuffer messageValue,
+        final int messageValueOffset,
+        final int messageValueLimit)
+    {
+        OctetsFW value = messageValue == null ? null : messageValueRO.wrap(messageValue, messageValueOffset, messageValueLimit);
+
+        final DataFW data = dataRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+                .streamId(targetId)
+                .trace(traceId)
+                .flags(flags)
+                .groupId(0)
+                .padding(padding)
+                .payload(value)
                 .build();
 
         target.accept(data.typeId(), data.buffer(), data.offset(), data.sizeof());
@@ -472,16 +502,22 @@ public final class ClientStreamFactory implements StreamFactory
         private PartitionProgressHandler progressHandler;
 
         private MessageConsumer streamState;
-        private int writeableBytesMinimum;
 
         private final DirectBuffer pendingMessageKeyBuffer = new UnsafeBuffer(EMPTY_BYTE_ARRAY);
         private final DirectBuffer pendingMessageValueBuffer = new UnsafeBuffer(EMPTY_BYTE_ARRAY);
 
-        private boolean messagePending;;
+        private boolean messagePending;
+        private boolean outOfWindow;
         private DirectBuffer pendingMessageKey;
         private long pendingMessageTimestamp;
         private long pendingMessageTraceId;
         private DirectBuffer pendingMessageValue;
+        private int pendingMessageValueOffset;
+        private int pendingMessageValueLimit;
+        private long pendingMessageOffset;
+
+        int fragmentedMessageBytesWritten;
+        long fragmentedMessageOffset = UNSET;
 
         private long progressStartOffset = UNSET;
         private long progressEndOffset;
@@ -508,7 +544,7 @@ public final class ClientStreamFactory implements StreamFactory
         public int dispatch(
             int partition,
             long requestOffset,
-            long messageOffset,
+            long messageStartOffset,
             DirectBuffer key,
             Function<DirectBuffer, Iterator<DirectBuffer>> supplyHeader,
             long timestamp,
@@ -524,62 +560,70 @@ public final class ClientStreamFactory implements StreamFactory
             if (compacted && (subscribedByKey || equals(key, pendingMessageKey)))
             {
                 // This message replaces the last one
-                if (messagePending)
+                if (messagePending && fragmentedMessageBytesWritten == 0)
                 {
                     messagePending = false;
                     final int previousLength = pendingMessageValue == null ? 0 : pendingMessageValue.capacity();
                     budget.incApplicationReplyBudget(previousLength + applicationReplyPadding);
                 }
-                writeableBytesMinimum = 0;
             }
             else
             {
-                flushPreviousMessage(partition, messageOffset - 1);
+                flushPreviousMessage(partition, messageStartOffset);
             }
 
             if (requestOffset <= progressStartOffset // avoid out of order delivery
-                && messageOffset > progressStartOffset)
+                && messageStartOffset >= progressStartOffset // avoid repeated delivery
+                && (fragmentedMessageOffset == UNSET || messageStartOffset == fragmentedMessageOffset)
+                )
             {
-                final int payloadLength = value == null ? 0 : value.capacity();
+                final int payloadLength = value == null ? 0 : value.capacity() - fragmentedMessageBytesWritten;
                 int applicationReplyBudget = budget.applicationReplyBudget();
-                if (applicationReplyBudget == 0 || applicationReplyBudget < payloadLength + applicationReplyPadding)
+                int writeableBytes = applicationReplyBudget - applicationReplyPadding;
+                if (writeableBytes > 0 || payloadLength == 0)
                 {
-                    writeableBytesMinimum = payloadLength + applicationReplyPadding;
-                }
-                else
-                {
-                    writeableBytesMinimum = 0;
-                    budget.decApplicationReplyBudget(payloadLength + applicationReplyPadding);
+                    int bytesToWrite = Math.min(payloadLength, writeableBytes);
+                    budget.decApplicationReplyBudget(bytesToWrite + applicationReplyPadding);
                     assert budget.applicationReplyBudget() >= 0;
 
                     pendingMessageKey = wrap(pendingMessageKeyBuffer, key);
                     pendingMessageTimestamp = timestamp;
                     pendingMessageTraceId = traceId;
                     pendingMessageValue = wrap(pendingMessageValueBuffer, value);
+                    pendingMessageValueOffset = fragmentedMessageBytesWritten;
+                    pendingMessageValueLimit = pendingMessageValueOffset + bytesToWrite;
+                    pendingMessageOffset = messageStartOffset;
                     messagePending = true;
                     result &= MessageDispatcher.FLAGS_DELIVERED;
+                }
+                else
+                {
+                    outOfWindow = true;
                 }
             }
             return result;
         }
 
         @Override
-        public void flush(int partition, long requestOffset, long lastOffset)
+        public void flush(
+            int partition,
+            long requestOffset,
+            long nextFetchOffset)
         {
-            flushPreviousMessage(partition, lastOffset);
+            flushPreviousMessage(partition, nextFetchOffset);
             long startOffset = progressStartOffset;
             long endOffset = progressEndOffset;
             if (startOffset == UNSET)
             {
-                // no messages were dispatched
+                // dispatch was not called
                 startOffset = fetchOffsets.get(partition);
-                endOffset = lastOffset;
+                endOffset = nextFetchOffset;
             }
             else if (requestOffset <= startOffset
-                    && writeableBytesMinimum == 0)
+                    && !outOfWindow && fragmentedMessageOffset == UNSET)
             {
-                // We didn't skip any messages due to lack of window, advance to highest offset
-                endOffset = lastOffset;
+                // We didn't skip or do partial write of any messages due to lack of window, advance to highest offset
+                endOffset = nextFetchOffset;
             }
             if (endOffset > startOffset && requestOffset <= startOffset)
             {
@@ -587,20 +631,46 @@ public final class ClientStreamFactory implements StreamFactory
                 progressHandler.handle(partition, startOffset, endOffset);
             }
             progressStartOffset = UNSET;
+            outOfWindow = false;
         }
 
         private void flushPreviousMessage(
                 int partition,
-                long messageOffset)
+                long nextFetchOffset)
         {
             if (messagePending)
             {
-                this.fetchOffsets.put(partition, messageOffset);
-                doKafkaData(applicationReply, applicationReplyId, pendingMessageTraceId, applicationReplyPadding,
-                            compacted ? pendingMessageKey : null,
-                            pendingMessageTimestamp, pendingMessageValue, fetchOffsets);
+                byte flags = pendingMessageValue == null || pendingMessageValue.capacity() == pendingMessageValueLimit
+                        ? FIN : 0;
+
+                if (pendingMessageValueOffset == 0)
+                {
+                    flags |= INIT;
+                    this.fetchOffsets.put(partition, nextFetchOffset);
+                    doKafkaData(applicationReply, applicationReplyId, pendingMessageTraceId, applicationReplyPadding, flags,
+                                compacted ? pendingMessageKey : null,
+                                pendingMessageTimestamp, pendingMessageValue, pendingMessageValueLimit, fetchOffsets);
+                }
+                else
+                {
+                    doKafkaDataContinuation(applicationReply, applicationReplyId, pendingMessageTraceId,
+                            applicationReplyPadding, flags, pendingMessageValue, pendingMessageValueOffset,
+                            pendingMessageValueLimit);
+                }
+
                 messagePending = false;
-                progressEndOffset = messageOffset;
+                if (Flags.fin(flags))
+                {
+                    fragmentedMessageBytesWritten = 0;
+                    fragmentedMessageOffset = UNSET;
+                    progressEndOffset = nextFetchOffset;
+                }
+                else
+                {
+                    fragmentedMessageBytesWritten += (pendingMessageValueLimit - pendingMessageValueOffset);
+                    fragmentedMessageOffset = pendingMessageOffset;
+                    progressEndOffset = pendingMessageOffset;
+                }
             }
         }
 
@@ -825,8 +895,7 @@ public final class ClientStreamFactory implements StreamFactory
 
         private int writeableBytes()
         {
-            final int writeableBytes = budget.applicationReplyBudget() - applicationReplyPadding;
-            return writeableBytes >= writeableBytesMinimum ? writeableBytes : 0;
+            return budget.applicationReplyBudget() - applicationReplyPadding;
         }
 
     }
@@ -860,8 +929,7 @@ public final class ClientStreamFactory implements StreamFactory
         @Override
         public void applicationReplyBudget(int budget)
         {
-            applicationReplyBudget = budget;
-        }
+            applicationReplyBudget = budget;        }
 
         @Override
         public void decApplicationReplyBudget(int data)

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/FetchResponseDecoder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/FetchResponseDecoder.java
@@ -565,7 +565,7 @@ public class FetchResponseDecoder implements ResponseDecoder
                 else
                 {
                     headers.wrap(buffer, headersOffset, headersLimit);
-                    messageDispatcher.dispatch(partition, requestedOffset, nextFetchAt, highWatermark,
+                    messageDispatcher.dispatch(partition, requestedOffset, currentFetchAt, highWatermark,
                             key, headers, timestamp, traceId, value);
                 }
             }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/FetchResponseDecoder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/FetchResponseDecoder.java
@@ -370,7 +370,7 @@ public class FetchResponseDecoder implements ResponseDecoder
             {
                 System.out.format(
                         "[nukleus-kafka] skipping topic: %s partition: %d offset: %d because record set size %d " +
-                        "exceeds configured partition.max.bytes %d",
+                        "exceeds configured nukleus.kafka.fetch.partition.max.bytes %d\n",
                         topicName, partition, requestedOffset, recordSetBytesRemaining, maxRecordBatchSize);
                 messageDispatcher.flush(partition, requestedOffset, requestedOffset + 1);
                 skipBytesDecoderState.bytesToSkip = recordSetBytesRemaining;
@@ -416,11 +416,12 @@ public class FetchResponseDecoder implements ResponseDecoder
             if (recordBatchActualSize > recordSetBytesRemaining
                 && recordBatch.lastOffsetDelta() == 0 && recordBatchActualSize > maxRecordBatchSize)
                 // record batch was truncated in response due to max fetch bytes or max partition bytes limit set on request,
-                // contains only one (necessarily incomplete) message, and is too large for our decoding buffer
+                // contains only one (necessarily incomplete) message
             {
                     System.out.format(
-                        "[nukleus-kafka] skipping large message at topic: %s partition: %d offset: %d batch-size: %d\n",
-                        topicName, partition, recordBatch.firstOffset(), recordBatch.length());
+                        "[nukleus-kafka] skipping large message at topic: %s partition: %d offset: %d, " +
+                            "message size %d bytes exceeds configured nukleus.kafka.fetch.partition.max.bytes %d\n",
+                        topicName, partition, recordBatch.firstOffset(), recordBatch.length(), maxRecordBatchSize);
                     nextFetchAt = recordBatch.firstOffset() + 1;
                     messageDispatcher.flush(partition, requestedOffset, nextFetchAt);
                     skipBytesDecoderState.bytesToSkip = recordSetBytesRemaining;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcher.java
@@ -44,7 +44,7 @@ public interface MessageDispatcher
     int dispatch(
         int partition,
         long requestOffset,
-        long messageOffset,
+        long messageStartOffset,
         DirectBuffer key,
         Function<DirectBuffer, Iterator<DirectBuffer>> supplyHeader,
         long timestamp,
@@ -54,6 +54,6 @@ public interface MessageDispatcher
     void flush(
         int partition,
         long requestOffset,
-        long lastOffset);
+        long nextFetchOffset);
 
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1894,7 +1894,6 @@ public final class NetworkConnectionPool
                     }
                     else
                     {
-                        newOffset++; // we always dispatch at next required fetch offset
                         DirectBuffer key = wrap(keyBuffer, message.key());
                         DirectBuffer value = wrap(valueBuffer,  message.value());
                         HeadersFW headers = headersRO.wrap(message.headers().buffer(),  message.headers().offset(),

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/util/Flags.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/util/Flags.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.util;
+
+public final class Flags
+{
+    public static final byte FIN = 0x01;
+    public static final byte INIT = 0x02;
+
+    public static  boolean fin(byte flags)
+    {
+        return (flags & FIN) != 0;
+    }
+
+}

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchLimitsIT.java
@@ -49,10 +49,25 @@ public class CachingFetchLimitsIT
         .counterValuesBufferCapacity(1024)
         .configure(KafkaConfiguration.TOPIC_BOOTSTRAP_ENABLED, "false")
         .configure(KafkaConfiguration.MESSAGE_CACHE_CAPACITY_PROPERTY, Integer.toString(1024 * 2))
+        .configure(KafkaConfiguration.MESSAGE_CACHE_PROACTIVE_PROPERTY, "true")
         .clean();
 
     @Rule
     public final TestRule chain = outerRule(reaktor).around(k3po).around(timeout);
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/compacted.historical.large.message.subscribed.to.key/client",
+        "${server}/compacted.messages.first.exceeds.256.bytes.repeated/server"})
+    @ScriptProperty({
+        "networkAccept \"nukleus://target/streams/kafka\"",
+        "applicationConnectWindow \"200\""
+    })
+    public void shouldReceiveCompactedFragmentedMessageFromCacheWhenSubscribedToKey() throws Exception
+    {
+        k3po.finish();
+    }
 
     @Test
     @Specification({

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -63,6 +63,31 @@ public class FetchLimitsIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/compacted.large.message.subscribed.to.key/client",
+        "${server}/compacted.messages.first.exceeds.256.bytes/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveLargeCompactedMessageWhenSubscribedToKey() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/compacted.large.message.subscribed.to.key/client",
+        "${server}/compacted.messages.first.exceeds.256.bytes.repeated/server"})
+    @ScriptProperty({
+        "networkAccept \"nukleus://target/streams/kafka\"",
+        "applicationConnectWindow \"200\""
+    })
+    public void shouldReceiveCompactedFragmentedMessageWhenSubscribedToKey() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/zero.offset.large.message/client",
         "${server}/zero.offset.messages.first.exceeds.256.bytes/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -51,7 +51,7 @@ public class FetchLimitsIT
         .clean()
         .configure(KafkaConfiguration.TOPIC_BOOTSTRAP_ENABLED, "false")
         .configure(ReaktorConfiguration.BUFFER_SLOT_CAPACITY_PROPERTY, 256)
-        .configure(KafkaConfiguration.FETCH_MAX_BYTES_PROPERTY, 256)
+        .configure(KafkaConfiguration.FETCH_MAX_BYTES_PROPERTY, 355)
         .configure(KafkaConfiguration.FETCH_PARTITION_MAX_BYTES_PROPERTY, 355);
 
     @Rule
@@ -68,8 +68,6 @@ public class FetchLimitsIT
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveMessageExceedingBufferSlotCapacity() throws Exception
     {
-        k3po.start();
-        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
         k3po.finish();
     }
 
@@ -77,15 +75,13 @@ public class FetchLimitsIT
     @Specification({
         "${route}/client/controller",
         "${client}/zero.offset.large.message/client",
-        "${server}/zero.offset.messages.first.exceeds.256.bytes.redelivered/server"})
+        "${server}/zero.offset.messages.first.exceeds.256.bytes.repeated/server"})
     @ScriptProperty({
-            "networkAccept \"nukleus://target/streams/kafka\"",
-            "applicationConnectWindow \"200\""
+        "networkAccept \"nukleus://target/streams/kafka\"",
+        "applicationConnectWindow \"200\""
     })
     public void shouldReceiveMessageExceedingInitialWindow() throws Exception
     {
-        k3po.start();
-        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
         k3po.finish();
     }
 
@@ -93,15 +89,13 @@ public class FetchLimitsIT
     @Specification({
         "${route}/client/controller",
         "${client}/zero.offset.large.message/client",
-        "${server}/zero.offset.first.record.batch.large/server"})
+        "${server}/zero.offset.first.record.batch.large.requires.3.fetches/server"})
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
-        "applicationConnectWindow \"50\""
+        "applicationConnectWindow \"100\""
 })
     public void shouldReceiveRecordBatchExceedingMaxPartitionBytes() throws Exception
     {
-        k3po.start();
-        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
         k3po.finish();
     }
 }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -118,8 +118,23 @@ public class FetchLimitsIT
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
         "applicationConnectWindow \"100\""
-})
-    public void shouldReceiveRecordBatchExceedingMaxPartitionBytes() throws Exception
+    })
+    public void shouldReceiveLargeMessageRequiringThreeDataFrames() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/zero.offset.message/client",
+        "${server}/message.size.exceeds.max.partition.bytes/server"})
+    @ScriptProperty({
+        "networkAccept \"nukleus://target/streams/kafka\"",
+        "applicationConnectWindow \"355\"",
+        "messageOffset \"2\""
+    })
+    public void shouldSkipRecordBatchExceedingMaxPartitionBytes() throws Exception
     {
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -52,7 +52,7 @@ public class FetchLimitsIT
         .configure(KafkaConfiguration.TOPIC_BOOTSTRAP_ENABLED, "false")
         .configure(ReaktorConfiguration.BUFFER_SLOT_CAPACITY_PROPERTY, 256)
         .configure(KafkaConfiguration.FETCH_MAX_BYTES_PROPERTY, 256)
-        .configure(KafkaConfiguration.FETCH_PARTITION_MAX_BYTES_PROPERTY, 336);
+        .configure(KafkaConfiguration.FETCH_PARTITION_MAX_BYTES_PROPERTY, 355);
 
     @Rule
     public final TestRule chain = outerRule(reaktor).around(k3po).around(timeout);
@@ -77,10 +77,10 @@ public class FetchLimitsIT
     @Specification({
         "${route}/client/controller",
         "${client}/zero.offset.large.message/client",
-        "${server}/zero.offset.messages.first.exceeds.256.bytes/server"})
+        "${server}/zero.offset.messages.first.exceeds.256.bytes.redelivered/server"})
     @ScriptProperty({
             "networkAccept \"nukleus://target/streams/kafka\"",
-            "applicationConnectWindow \"100\""
+            "applicationConnectWindow \"200\""
     })
     public void shouldReceiveMessageExceedingInitialWindow() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -66,7 +66,7 @@ public class FetchLimitsIT
         "${client}/zero.offset.large.message/client",
         "${server}/zero.offset.messages.first.exceeds.256.bytes/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldSkipMessageExceedingMaximumSupportedMessageSize() throws Exception
+    public void shouldReceiveMessageExceedingBufferSlotCapacity() throws Exception
     {
         k3po.start();
         k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
@@ -76,10 +76,13 @@ public class FetchLimitsIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/zero.offset.large.response/client",
-        "${server}/zero.offset.large.response/server"})
-    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldHandleLargeFetchResponseProvidedEachRecordBatchLessThanMaxPartitionBytes() throws Exception
+        "${client}/zero.offset.large.message/client",
+        "${server}/zero.offset.messages.first.exceeds.256.bytes/server"})
+    @ScriptProperty({
+            "networkAccept \"nukleus://target/streams/kafka\"",
+            "applicationConnectWindow \"100\""
+    })
+    public void shouldReceiveMessageExceedingInitialWindow() throws Exception
     {
         k3po.start();
         k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
@@ -91,8 +94,11 @@ public class FetchLimitsIT
         "${route}/client/controller",
         "${client}/zero.offset.large.message/client",
         "${server}/zero.offset.first.record.batch.large/server"})
-    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldSkipRecordBatchExceedingMaxRecordBatchSize() throws Exception
+    @ScriptProperty({
+        "networkAccept \"nukleus://target/streams/kafka\"",
+        "applicationConnectWindow \"50\""
+})
+    public void shouldReceiveRecordBatchExceedingMaxPartitionBytes() throws Exception
     {
         k3po.start();
         k3po.notifyBarrier("WRITE_FETCH_RESPONSE");

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcherTest.java
@@ -106,7 +106,7 @@ public final class TopicMessageDispatcherTest
                 oneOf(child2).dispatch(with(1), with(10L), with(12L), with((DirectBuffer) null),
                         with(headers.headerSupplier()), with(timestamp), with(traceId), with((DirectBuffer) null));
                 will(returnValue(FLAGS_DELIVERED));
-                oneOf(partitionIndex2).add(with(10L), with(11L), with(timestamp), with(traceId),
+                oneOf(partitionIndex2).add(with(10L), with(12L), with(timestamp), with(traceId),
                         with((DirectBuffer) null), with(headers), with((DirectBuffer) null), with(false));
             }
         });
@@ -141,7 +141,7 @@ public final class TopicMessageDispatcherTest
                 oneOf(partitionIndex1).getEntry(with(10L), with(asOctets("key1")));
                 oneOf(partitionIndex1).nextOffset();
                 will(returnValue(0L));
-                oneOf(partitionIndex1).add(with(10L), with(11L), with(timestamp1), with(traceId),
+                oneOf(partitionIndex1).add(with(10L), with(12L), with(timestamp1), with(traceId),
                         with(bufferMatching("key1")), with(headers), with((DirectBuffer) null), with(false));
 
                 oneOf(child3).dispatch(with(1), with(10L), with(13L), with(bufferMatching("key2")),
@@ -150,7 +150,7 @@ public final class TopicMessageDispatcherTest
                 oneOf(partitionIndex2).getEntry(with(10L), with(asOctets("key2")));
                 oneOf(partitionIndex2).nextOffset();
                 will(returnValue(0L));
-                oneOf(partitionIndex2).add(with(10L), with(12L), with(timestamp1), with(traceId),
+                oneOf(partitionIndex2).add(with(10L), with(13L), with(timestamp1), with(traceId),
                         with(bufferMatching("key2")), with(headers), with((DirectBuffer) null), with(false));
             }
         });
@@ -183,7 +183,7 @@ public final class TopicMessageDispatcherTest
                 oneOf(routeMatcher).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key2")),
                         with(headers.headerSupplier()), with(timestamp), with(0L), with((DirectBuffer) null));
                 will(returnValue(MessageDispatcher.FLAGS_MATCHED));
-                oneOf(partitionIndex2).add(with(10L), with(11L), with(timestamp), with(0L),
+                oneOf(partitionIndex2).add(with(10L), with(12L), with(timestamp), with(0L),
                         with(bufferMatching("key2")), with(headers), with((DirectBuffer) null), with(false));
             }
         });
@@ -214,7 +214,7 @@ public final class TopicMessageDispatcherTest
                 oneOf(routeMatcher).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key2")),
                         with(headers.headerSupplier()), with(timestamp), with(0L), with((DirectBuffer) null));
                 will(returnValue(MessageDispatcher.FLAGS_MATCHED));
-                oneOf(partitionIndex2).add(with(10L), with(11L), with(timestamp), with(0L),
+                oneOf(partitionIndex2).add(with(10L), with(12L), with(timestamp), with(0L),
                         with(bufferMatching("key2")), with(headers), with((DirectBuffer) null), with(true));
             }
         });
@@ -243,7 +243,7 @@ public final class TopicMessageDispatcherTest
                 oneOf(partitionIndex2).getEntry(with(10L), with(asOctets("key2")));
                 oneOf(partitionIndex2).nextOffset();
                 will(returnValue(0L));
-                oneOf(routeMatcher).dispatch(with(1), with(10L), with(12L), with(bufferMatching("key2")),
+                oneOf(routeMatcher).dispatch(with(1), with(10L), with(11L), with(bufferMatching("key2")),
                         with(headers.headerSupplier()), with(timestamp), with(0L), with((DirectBuffer) null));
                 will(returnValue(MessageDispatcher.FLAGS_MATCHED));
                 oneOf(partitionIndex2).add(with(10L), with(11L), with(timestamp), with(0L),
@@ -251,7 +251,7 @@ public final class TopicMessageDispatcherTest
             }
         });
         assertEquals(MessageDispatcher.FLAGS_MATCHED,
-                dispatcher.dispatch(1, 10L, 12L, 12L, asBuffer("key2"), headers, timestamp, 0L, null));
+                dispatcher.dispatch(1, 10L, 11L, 12L, asBuffer("key2"), headers, timestamp, 0L, null));
     }
 
     @Test


### PR DESCRIPTION
Requires:
- https://github.com/reaktivity/nukleus-kafka.spec/pull/52
- https://github.com/reaktivity/nukleus-maven-plugin/pull/69

Also requires the changes in PR https://github.com/reaktivity/nukleus-kafka.java/pull/90 for  one of the tests to pass, so the build of the present PR will fail until #90 is merged and merged into this one.

I have successfully tested these changes against local stack.