### PR TITLE
Fixes to allow moving onto live stream after getting a message from the cache to match a key subscription

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/CompactedPartitionIndex.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/CompactedPartitionIndex.java
@@ -152,7 +152,7 @@ public class CompactedPartitionIndex implements PartitionIndex
         long requestOffset,
         long lastOffset)
     {
-        if (requestOffset < validToOffset)
+        if (requestOffset <= validToOffset)
         {
             validToOffset = Math.max(lastOffset,  validToOffset);
         }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -557,7 +557,7 @@ public final class ClientStreamFactory implements StreamFactory
                     pendingMessageTraceId = traceId;
                     pendingMessageValue = wrap(pendingMessageValueBuffer, value);
                     messagePending = true;
-                    result &= MessageDispatcher.FLAGS_DELIVERED;
+                    result |= MessageDispatcher.FLAGS_DELIVERED;
                 }
             }
             return result;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcher.java
@@ -28,17 +28,17 @@ public interface MessageDispatcher
 
     static boolean matched(int result)
     {
-        return (result & FLAGS_MATCHED) != 0;
+        return (result & FLAGS_MATCHED) == FLAGS_MATCHED;
     }
 
     static boolean delivered(int result)
     {
-        return (result & FLAGS_DELIVERED) != 0;
+        return (result & FLAGS_DELIVERED) == FLAGS_DELIVERED;
     }
 
     static boolean blocked(int result)
     {
-        return (result & FLAGS_BLOCKED) != 0;
+        return (result & FLAGS_BLOCKED) == FLAGS_BLOCKED;
     }
 
     int dispatch(

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1914,7 +1914,8 @@ public final class NetworkConnectionPool
                                 message.timestamp(), message.traceId(), value);
 
                         flushNeeded = true;
-                        if (!needsHistorical(partitionId) || // caught up to live stream
+                        if (!needsHistorical(partitionId) // caught up to live stream
+                            ||
                             (MessageDispatcher.blocked(dispatched) &&
                             !MessageDispatcher.delivered(dispatched)))
                             // TODO: this may be too conservative, other dispatchers which did not match this message

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1914,11 +1914,12 @@ public final class NetworkConnectionPool
                                 message.timestamp(), message.traceId(), value);
 
                         flushNeeded = true;
-                        if (MessageDispatcher.blocked(dispatched) &&
-                                !MessageDispatcher.delivered(dispatched))
-                        {
+                        if (!needsHistorical(partitionId) || // caught up to live stream
+                            (MessageDispatcher.blocked(dispatched) &&
+                            !MessageDispatcher.delivered(dispatched)))
                             // TODO: this may be too conservative, other dispatchers which did not match this message
                             //       might still have available window to deliver later messages
+                        {
                             requestSatisifed = true;
                             break;
                         }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcherTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public final class MessageDispatcherTest
+{
+    @Test
+    public void shouldDetectFlagsBlocked()
+    {
+        assertFalse(MessageDispatcher.blocked(0x01));
+        assertFalse(MessageDispatcher.blocked(0x02));
+        assertFalse(MessageDispatcher.blocked(0x03));
+        assertFalse(MessageDispatcher.blocked(0x04));
+        assertTrue(MessageDispatcher.blocked(0x05));
+        assertFalse(MessageDispatcher.blocked(0x08));
+    }
+
+    @Test
+    public void shouldDetectFlagsDelivered()
+    {
+        assertFalse(MessageDispatcher.delivered(0x01));
+        assertFalse(MessageDispatcher.delivered(0x02));
+        assertTrue(MessageDispatcher.delivered(0x03));
+        assertFalse(MessageDispatcher.delivered(0x05));
+        assertTrue(MessageDispatcher.delivered(0x07));
+    }
+
+    @Test
+    public void shouldDetectFlagsMatched()
+    {
+        assertTrue(MessageDispatcher.matched(0x01));
+        assertTrue(MessageDispatcher.matched(0x03));
+        assertFalse(MessageDispatcher.matched(0x02));
+    }
+}


### PR DESCRIPTION
Before these fixes a subscription to a specific key was satisfied from the cache but historical fetches ensued.