### PR TITLE
Fixed CompactedPartitionIndex leak, got tombstone expiry time from Kakfa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
-  - cd nukleus-kafka.spec
-  - git checkout 93_cpi_leak
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkout 93_cpi_leak
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.66</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.57</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.67</nukleus.kafka.spec.version>
     <reaktor.version>0.57</reaktor.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/CompactedPartitionIndex.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/CompactedPartitionIndex.java
@@ -100,6 +100,13 @@ public class CompactedPartitionIndex implements PartitionIndex
                 entry.offset = messageStartOffset;
             }
             entries.add(entry);
+            if (value == null)
+            {
+                MutableDirectBuffer keyCopy = new UnsafeBuffer(new byte[key.capacity()]);
+                keyCopy.putBytes(0,  key, 0, key.capacity());
+                tombstoneKeys.add(keyCopy);
+                tombstoneExpiryTimes.add(timestamp + tombstoneLifetimeMillis);
+            }
             if (cacheNewMessages)
             {
                 cacheMessage(entry, timestamp, traceId, key, headers, value);
@@ -187,13 +194,6 @@ public class CompactedPartitionIndex implements PartitionIndex
         HeadersFW headers,
         DirectBuffer value)
     {
-        if (value == null)
-        {
-            MutableDirectBuffer keyCopy = new UnsafeBuffer(new byte[key.capacity()]);
-            keyCopy.putBytes(0,  key, 0, key.capacity());
-            tombstoneKeys.add(keyCopy);
-            tombstoneExpiryTimes.add(timestamp + tombstoneLifetimeMillis);
-        }
         if (entry.message == NO_MESSAGE)
         {
             entry.message = messageCache.put(timestamp, traceId, key, headers, value);

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1689,7 +1689,6 @@ public final class NetworkConnectionPool
             {
                 for (int i = 0; i < partitionCount; i++)
                 {
-                    // TODO: read topic config "delete.retention.ms" and use that value if set
                     partitionIndexes[i] = new CompactedPartitionIndex(1000, deleteRetentionMs,
                             messageCache);
                 }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
@@ -177,6 +177,24 @@ public class BootstrapIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/compacted.message/client",
+        "${server}/compacted.tombstone.then.message/server"})
+    @ScriptProperty({ "networkAccept \"nukleus://target/streams/kafka\"",
+                      "messageOffset 12L" })
+    public void shouldNotCacheExpiredTombstoneKeyAndOffset() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_CLIENT");
+        k3po.awaitBarrier("RECEIVED_SECOND_FETCH_REQUEST");
+        k3po.notifyBarrier("CONNECT_CLIENT");
+        k3po.awaitBarrier("CLIENT_CONNECTED");
+        k3po.notifyBarrier("DELIVER_SECOND_FETCH_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${metadata}/one.topic.error.unknown.topic/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldIssueWarningWhenBootstrapUnkownTopic() throws Exception

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -347,6 +347,7 @@ public class FetchIT
     public void shouldReceiveCompactedAdjacentRepeatedTombstoneMessages() throws Exception
     {
         k3po.start();
+        k3po.awaitBarrier("ROUTED_CLIENT");
         k3po.awaitBarrier("RECEIVED_NEXT_FETCH_REQUEST");
         k3po.notifyBarrier("SUBSCRIBE_CLIENT");
         k3po.finish();


### PR DESCRIPTION
NOTE: requires https://github.com/reaktivity/nukleus-kafka.spec/pull/55, fixes #93

Moved handling of expiry for tombstones into add method from cacheMessage, so we will expire tombstone entries out of the index after bootstrap. Added logic to read the configured value of delete.retention.ms from Kafka instead of the hardcoded Kafka server default value.