### PR TITLE
Changed processing of metadata response to treat error code -1 (unknown error)

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
@@ -241,9 +241,9 @@ public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
                 topicName));
             break;
         default:
-            throw new IllegalStateException(format(
-                "Received error code %d from Kafka while attempting to bootstrap topic \"%s\"",
-                errorCode, topicName));
+            System.out.println(format(
+                "WARNING: bootstrap failed while getting metadata for topic \"%s\" with error code %d",
+                topicName, errorCode));
         }
     }
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -334,7 +334,7 @@ public final class ClientStreamFactory implements StreamFactory
         target.accept(end.typeId(), end.buffer(), end.offset(), end.sizeof());
     }
 
-    private void doAbort(
+    void doAbort(
         final MessageConsumer target,
         final long targetId)
     {

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KafkaErrors.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KafkaErrors.java
@@ -24,7 +24,7 @@ public class KafkaErrors
     static final short NOT_LEADER_FOR_PARTITION = 6;
     static final short INVALID_TOPIC_EXCEPTION = 17;
     static final short TOPIC_AUTHORIZATION_FAILED = 29;
-    static final short UNKNOWN = -1;
+    static final short UNEXPECTED_SERVER_ERROR = -1;
 
     static boolean isRecoverable(short errorCode)
     {

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1639,7 +1639,6 @@ public final class NetworkConnectionPool
             {
                 // internal Kafka error, trigger connection failed and reconnect
                 pendingTopicMetadata.reset();
-                System.out.println("Unexpected server error from metadata query, aborting metadata connection");
                 abort();
             }
             else


### PR DESCRIPTION
as a connection failure by aborting the metadata connection to force reconnect and retry of the metadata query. Also changed route bootstrap to avoid ever causing a hard fail.