### PR TITLE
Fixes for stuck historical message flow and  IndexOutOfBoundsException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkout issue_492_stuck_flow
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
-  - cd nukleus-kafka.spec
-  - git checkout issue_492_stuck_flow
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.22</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.71</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.59</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.22</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.72</nukleus.kafka.spec.version>
     <reaktor.version>0.59</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/CompactedPartitionIndex.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/CompactedPartitionIndex.java
@@ -141,7 +141,7 @@ public class CompactedPartitionIndex implements PartitionIndex
     {
         Iterator<Entry> result;
         int position = locate(requestOffset);
-        if (position == -1)
+        if (position == NO_POSITION)
         {
             long offset = Math.max(requestOffset, validToOffset);
             result = noMessagesIterator.reset(offset);

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -15,6 +15,7 @@
  */
 package org.reaktivity.nukleus.kafka.internal.stream;
 
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.reaktivity.nukleus.kafka.internal.util.BufferUtil.EMPTY_BYTE_ARRAY;
 import static org.reaktivity.nukleus.kafka.internal.util.BufferUtil.wrap;
@@ -670,6 +671,17 @@ public final class ClientStreamFactory implements StreamFactory
             }
             progressStartOffset = UNSET;
             dispatchBlocked = false;
+        }
+
+        @Override
+        public String toString()
+        {
+            return format("fetchOffsets %s, fragmentedMessageOffset %d, fragmentedMessagePartition %d, " +
+                                 "applicationId %x, applicationReplyId %x",
+                    ClientAcceptStream.this.fetchOffsets,
+                    ClientAcceptStream.this.fragmentedMessageOffset,
+                    ClientAcceptStream.this.applicationId,
+                    ClientAcceptStream.this.applicationReplyId);
         }
 
         private void flushPreviousMessage(

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -912,7 +912,6 @@ public final class ClientStreamFactory implements StreamFactory
                 budget.incApplicationReplyBudget(window.credit());
             }
 
-            System.out.format("[networkPool.doFlush()] %s budget=%s\n", window, budget);
             networkPool.doFlush();
         }
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -911,6 +911,8 @@ public final class ClientStreamFactory implements StreamFactory
             {
                 budget.incApplicationReplyBudget(window.credit());
             }
+
+            System.out.format("[networkPool.doFlush()] %s budget=%s\n", window, budget);
             networkPool.doFlush();
         }
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -627,19 +627,19 @@ public final class ClientStreamFactory implements StreamFactory
                     {
                         dispatchBlocked = true;
                     }
+                    else
+                    {
+                        result |= MessageDispatcher.FLAGS_DELIVERED;
+                    }
                 }
                 else
                 {
                     dispatchBlocked = true;
                 }
-                if (dispatchBlocked)
-                {
-                    result |= MessageDispatcher.FLAGS_BLOCKED;
-                }
-                else
-                {
-                    result |= MessageDispatcher.FLAGS_DELIVERED;
-                }
+            }
+            if (dispatchBlocked)
+            {
+                result |= MessageDispatcher.FLAGS_BLOCKED;
             }
             return result;
         }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -586,6 +586,7 @@ public final class ClientStreamFactory implements StreamFactory
                 if (messagePending && fragmentedMessageBytesWritten == 0)
                 {
                     messagePending = false;
+                    dispatchBlocked = false;
                     final int previousLength = pendingMessageValue == null ? 0 : pendingMessageValue.capacity();
                     budget.incApplicationReplyBudget(previousLength + applicationReplyPadding);
                 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -511,7 +511,6 @@ public final class NetworkConnectionPool
     abstract class AbstractNetworkConnection
     {
         final MessageConsumer networkTarget;
-        boolean tempPostBegin;
 
         long networkId;
         long networkCorrelationId;
@@ -586,7 +585,6 @@ public final class NetworkConnectionPool
 
                 this.networkId = newNetworkId;
                 this.networkCorrelationId = newCorrelationId;
-                tempPostBegin = true;
             }
         }
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1301,8 +1301,9 @@ public final class NetworkConnectionPool
         @Override
         public String toString()
         {
-            return String.format("%s [brokerId=%d, host=%s, port=%d, budget=%d, padding=%d]",
-                    getClass().getName(), brokerId, host, port, networkRequestBudget, networkRequestPadding);
+            return String.format("%s [brokerId=%d, host=%s, port=%d, budget=%d, padding=%d, networkId=%d, networkReplyId=%d]",
+                    getClass().getName(), brokerId, host, port, networkRequestBudget, networkRequestPadding,
+                    networkId, networkReplyId);
         }
     }
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -2102,7 +2102,7 @@ public final class NetworkConnectionPool
                 Iterator<Entry> entries = dispatcher.entries(partitionId, fetchOffset);
                 boolean partitionRequestNeeded = false;
                 boolean flushNeeded = false;
-                long requestOffset = getRequestedOffset.applyAsLong(partitionId);
+                final long requestOffset = getRequestedOffset.applyAsLong(partitionId);
 
                 while(entries.hasNext())
                 {
@@ -2122,7 +2122,7 @@ public final class NetworkConnectionPool
                                 message.headers().limit());
 
                         // call the dispatch variant which does not attempt to re-cache the message
-                        int dispatched = dispatcher.dispatch(partitionId, fetchOffset, newOffset, key, headers.headerSupplier(),
+                        int dispatched = dispatcher.dispatch(partitionId, requestOffset, newOffset, key, headers.headerSupplier(),
                                 message.timestamp(), message.traceId(), value);
 
                         flushNeeded = true;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -55,6 +55,7 @@ import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.collections.IntArrayList;
 import org.agrona.collections.Long2LongHashMap;
 import org.agrona.collections.Long2LongHashMap.LongIterator;
+import org.agrona.collections.LongArrayList;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.reaktivity.nukleus.buffer.BufferPool;
 import org.reaktivity.nukleus.function.MessageConsumer;
@@ -260,6 +261,8 @@ public final class NetworkConnectionPool
     private final Map<String, List<ListFW<KafkaHeaderFW>>> routeHeadersByTopic;
     private final Int2ObjectHashMap<Consumer<Long2LongHashMap>> detachersById;
 
+    private final List<NetworkTopicPartition> partitionsWorkList = new ArrayList<NetworkTopicPartition>();
+    private final LongArrayList offsetsWorkList = new LongArrayList();
     private int nextAttachId;
 
     NetworkConnectionPool(
@@ -1339,6 +1342,7 @@ public final class NetworkConnectionPool
                 Iterator<NetworkTopicPartition> iterator = topic.partitions.iterator();
                 NetworkTopicPartition candidate = iterator.hasNext() ? iterator.next() : null;
                 NetworkTopicPartition next;
+
                 while (candidate != null)
                 {
                     next = iterator.hasNext() ? iterator.next() : null;
@@ -1354,18 +1358,41 @@ public final class NetworkConnectionPool
                             .maxBytes(maxPartitionBytes)
                             .build();
 
+                        long requestedOffset = candidate.offset;
+
                         if (offset < candidate.offset)
                         {
                             // Topic was recreated, we have to go back to an earlier offset
                             topic.dispatcher.adjustOffset(candidate.id, candidate.offset, offset);
-                            candidate.offset = offset; // TODO: this is wrong, must remove and add from topic.partitions
-                            throw new IllegalStateException("Illegal update of candidate.offset");
+                            requestedOffset = offset;
+
+                            // Prepare to update the partition offset later
+                            NetworkTopicPartition partition = candidate.clone();
+                            partitionsWorkList.add(partition);
+                            offsetsWorkList.addLong(offset);
                         }
-                        setRequestedOffset.accept(candidate.id,  candidate.offset);
+
+                        setRequestedOffset.accept(candidate.id, requestedOffset);
                         encodeLimit = partitionRequest.limit();
                         partitionCount++;
                     }
                     candidate = next;
+                }
+
+                if (!partitionsWorkList.isEmpty())
+                {
+                    // Update the partition offsets. We must remove and add to preserve ordering.
+                    for (int i=0; i < partitionsWorkList.size(); i++)
+                    {
+                        NetworkTopicPartition partition = partitionsWorkList.get(i);
+                        boolean removed = topic.partitions.remove(partition);
+                        assert removed;
+                        partition.offset = offsetsWorkList.getLong(i);
+                        topic.partitions.add(partition);
+                    }
+
+                    partitionsWorkList.clear();
+                    offsetsWorkList.clear();
                 }
             }
 
@@ -1405,9 +1432,14 @@ public final class NetworkConnectionPool
                     final int[] nodeIdsByPartition = metadata.nodeIdsByPartition;
 
                     int partitionId = -1;
+
                     // TODO: eliminate iterator allocation
-                    for (NetworkTopicPartition partition : topic.partitions)
+                    Iterator<NetworkTopicPartition> partitions = topic.partitions.iterator();
+
+                    while (partitions.hasNext())
                     {
+                        NetworkTopicPartition partition = partitions.next();
+
                         if (topic.needsHistorical(partition.id) &&
                                 partitionId < partition.id && nodeIdsByPartition[partition.id] == brokerId)
                         {
@@ -1423,9 +1455,11 @@ public final class NetworkConnectionPool
                             if (offset < partition.offset)
                             {
                                 // Topic was recreated, we have to go back to an earlier offset
+                                // We must remove and add the partition to preserve ordering
                                 topic.dispatcher.adjustOffset(partition.id, partition.offset, offset);
-                                partition.offset = offset; // TODO: this is wrong, must remove and add from topic.partitions
-                                throw new IllegalStateException("Illegal update of partition.offset");
+                                partitions.remove();
+                                partition.offset = offset;
+                                partitionsWorkList.add(partition);
                             }
                             setRequestedOffset.accept(partition.id,  partition.offset);
                             encodeLimit = partitionRequest.limit();
@@ -1433,6 +1467,13 @@ public final class NetworkConnectionPool
                             partitionCount++;
                         }
                     }
+
+                    if (!partitionsWorkList.isEmpty())
+                    {
+                        topic.partitions.addAll(partitionsWorkList);
+                        partitionsWorkList.clear();
+                    }
+
                     partitionCount = topic.satisfyPartitionRequestsFromCache(
                             partitionCount,
                             getRequestedOffset,
@@ -2236,6 +2277,16 @@ public final class NetworkConnectionPool
         int id;
         long offset;
         private int refs;
+
+        @Override
+        protected NetworkTopicPartition clone()
+        {
+            NetworkTopicPartition result = new NetworkTopicPartition();
+            result.id = id;
+            result.offset = offset;
+            result.refs = refs;
+            return result;
+        }
 
         @Override
         public int compareTo(

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -2075,6 +2075,8 @@ public final class NetworkConnectionPool
                                 message.timestamp(), message.traceId(), value);
 
                         flushNeeded = true;
+                        newOffset++;
+
                         if (!needsHistorical(partitionId) // caught up to live stream
                             ||
                             (MessageDispatcher.blocked(dispatched) &&
@@ -2089,7 +2091,10 @@ public final class NetworkConnectionPool
                 }
                 if (requestSatisifed)
                 {
-                    newOffset = dispatcher.nextOffset(partitionId);
+                    if (!entries.hasNext())
+                    {
+                        newOffset = dispatcher.nextOffset(partitionId);
+                    }
                     // Remove the partition request by shifting up the subsequent ones
                     encodeBuffer.putBytes(encodeOffset,  encodeBuffer, request.limit(), encodeLimit);
                     newEncodeLimit -= request.sizeof();

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -2180,7 +2180,6 @@ public final class NetworkConnectionPool
                         // caught up to live stream
                         System.out.format("[satisfyPartitionRequestsFromCache()] caught up to live on partition=%d\n",
                                 partitionId);
-                        break;
                     }
                 }
             } // end for each partition

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcher.java
@@ -15,6 +15,8 @@
  */
 package org.reaktivity.nukleus.kafka.internal.stream;
 
+import static java.lang.String.format;
+
 import java.util.Iterator;
 import java.util.function.Function;
 
@@ -90,8 +92,13 @@ public class TopicMessageDispatcher implements MessageDispatcher, DecoderMessage
                 traceId, value);
         if (messageOffset + 1 == highWatermark)
         {
-            // Caught up to live stream, enable proactive message caching
-            cacheNewMessages[partition] = true;
+            // Caught up to live stream, enable pro-active message caching
+            if (!cacheNewMessages[partition])
+            {
+                System.out.println(format("Caught up to live stream, partition %d highWatermark %d",
+                        partition, highWatermark));
+                cacheNewMessages[partition] = true;
+            }
         }
         if (MessageDispatcher.matched(result))
         {

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcher.java
@@ -15,8 +15,6 @@
  */
 package org.reaktivity.nukleus.kafka.internal.stream;
 
-import static java.lang.String.format;
-
 import java.util.Iterator;
 import java.util.function.Function;
 
@@ -90,21 +88,19 @@ public class TopicMessageDispatcher implements MessageDispatcher, DecoderMessage
     {
         int result = dispatch(partition, requestOffset, messageOffset, key, headers.headerSupplier(), timestamp,
                 traceId, value);
+
         if (messageOffset + 1 == highWatermark)
         {
             // Caught up to live stream, enable pro-active message caching
-            if (!cacheNewMessages[partition])
-            {
-                System.out.println(format("Caught up to live stream, partition %d highWatermark %d",
-                        partition, highWatermark));
-                cacheNewMessages[partition] = true;
-            }
+            cacheNewMessages[partition] = true;
         }
+
         if (MessageDispatcher.matched(result))
         {
             indexes[partition].add(requestOffset, messageOffset, timestamp, traceId, key, headers, value,
                     cacheNewMessages[partition]);
         }
+
         return result;
     }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
@@ -221,7 +221,6 @@ public class CachingFetchIT
         "${client}/compacted.historical.uses.cached.key.then.live/client",
         "${server}/compacted.historical.uses.cached.key.then.live.no.historical/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    // TODO: Fix failure
     public void shouldReceiveCompactedMessageUsingCachedKeyOffsetThenCatchUpToLiveStream() throws Exception
     {
         k3po.start();

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
@@ -162,6 +162,17 @@ public class CachingFetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/compacted.header.message.multiple.clients/client",
+        "${server}/compacted.header.first.matches.repeated/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveHistoricalMessageMatchingHeaderFirstFromCache() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/compacted.header.messages.and.tombstone/client",
         "${server}/compacted.header.matches.removed.in.subsequent.response/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
@@ -700,17 +711,6 @@ public class CachingFetchIT
         "${server}/header.zero.offset.first.matches/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveMessageMatchingHeaderFirst() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${route}/client/controller",
-        "${client}/compacted.header.message.multiple.clients/client",
-        "${server}/compacted.header.first.matches.repeated/server"})
-    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldReceiveHistoricalMessageMatchingHeaderFirstFromCache() throws Exception
     {
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
@@ -707,6 +707,17 @@ public class CachingFetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/compacted.header.message.multiple.clients/client",
+        "${server}/compacted.header.first.matches.repeated/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveHistoricalMessageMatchingHeaderFirstFromCache() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/header.zero.offset.message/client",
         "${server}/header.zero.offset.last.matches/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingProactiveFetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingProactiveFetchIT.java
@@ -66,4 +66,16 @@ public class CachingProactiveFetchIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/compacted.header.message.multiple.clients/client",
+        "${server}/compacted.header.first.matches/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveHistoricalMessageMatchingHeaderFromCache() throws Exception
+    {
+        k3po.finish();
+    }
+
 }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -1083,6 +1083,36 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/header.large.then.small.messages.multiple.partitions/client",
+        "${server}/header.large.then.small.messages.multiple.partitions/server" })
+    @ScriptProperty({
+        "networkAccept \"nukleus://target/streams/kafka\"",
+        "applicationConnectWindow \"200\""
+    })
+    public void shouldAdvanceFetchOffsetForNonMatchingMessagesOnPartitionDifferentFromFragmentedMessage()
+            throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/large.then.small.messages.multiple.partitions/client",
+        "${server}/large.then.small.messages.multiple.partitions/server" })
+    @ScriptProperty({
+        "networkAccept \"nukleus://target/streams/kafka\"",
+        "applicationConnectWindow \"200\""
+    })
+    public void shouldNotDeliverMessageFromPartitionDifferentFromFragmentedMessageUntilFragmentedFullyWritten()
+            throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/zero.offset.messages.topic.recreated/client",
         "${server}/live.fetch.broker.restarted.with.recreated.topic/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -928,6 +928,17 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/record.batch.ends.with.truncated.record.length/client",
+        "${server}/record.batch.ends.with.truncated.record.length/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveMessageWithTruncatedRecordLength() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/record.batch.truncated/client",
         "${server}/record.batch.truncated/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -1114,12 +1114,12 @@ public class FetchIT
     @Specification({
         "${route}/client/controller",
         "${client}/large.then.small.messages.multiple.partitions/client",
-        "${server}/large.exceeding.window.then.small.messages.multiple.partitions/server" })
+        "${server}/large.equals.window.then.small.messages.multiple.partitions/server" })
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
-        "applicationConnectWindow \"200\""
+        "applicationConnectWindow \"266\""
     })
-    public void shouldNotDeliverMessageFromPartitionDifferentFromFragmentedMessageUntilFragmentedFullyWritten()
+    public void shouldDeliverLargeMessageFillingWindowThenSmallMessagesFromMultiplePartitions()
             throws Exception
     {
         k3po.finish();
@@ -1129,12 +1129,12 @@ public class FetchIT
     @Specification({
         "${route}/client/controller",
         "${client}/large.then.small.messages.multiple.partitions/client",
-        "${server}/large.equals.window.then.small.messages.multiple.partitions/server" })
+        "${server}/large.exceeding.window.then.small.messages.multiple.partitions/server" })
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
-        "applicationConnectWindow \"266\""
+        "applicationConnectWindow \"200\""
     })
-    public void shouldDeliverLargeMessageFillingWindowThenSmallMessagesFromMultiplePartitions()
+    public void shouldNotDeliverMessageFromPartitionDifferentFromFragmentedMessageUntilFragmentedFullyWritten()
             throws Exception
     {
         k3po.finish();

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -1084,7 +1084,7 @@ public class FetchIT
     @Specification({
         "${route}/client/controller",
         "${client}/header.large.then.small.messages.multiple.partitions/client",
-        "${server}/header.large.then.small.messages.multiple.partitions/server" })
+        "${server}/header.large.exceeding.window.then.small.messages.multiple.partitions/server" })
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
         "applicationConnectWindow \"200\""
@@ -1098,13 +1098,58 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/header.large.then.small.messages.multiple.partitions/client",
+        "${server}/header.large.equals.window.then.small.messages.multiple.partitions/server" })
+    @ScriptProperty({
+        "networkAccept \"nukleus://target/streams/kafka\"",
+        "applicationConnectWindow \"266\""
+    })
+    public void shouldAdvanceFetchOffsetForNonMatchingMessagesOnPartitionDifferentFromMessageExhaustingWindow()
+            throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/large.then.small.messages.multiple.partitions/client",
-        "${server}/large.then.small.messages.multiple.partitions/server" })
+        "${server}/large.exceeding.window.then.small.messages.multiple.partitions/server" })
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
         "applicationConnectWindow \"200\""
     })
     public void shouldNotDeliverMessageFromPartitionDifferentFromFragmentedMessageUntilFragmentedFullyWritten()
+            throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/large.then.small.messages.multiple.partitions/client",
+        "${server}/large.equals.window.then.small.messages.multiple.partitions/server" })
+    @ScriptProperty({
+        "networkAccept \"nukleus://target/streams/kafka\"",
+        "applicationConnectWindow \"266\""
+    })
+    public void shouldDeliverLargeMessageFillingWindowThenSmallMessagesFromMultiplePartitions()
+            throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/large.then.small.messages.multiple.partitions/client",
+        "${server}/large.then.small.other.partition.first.in.next.response/server" })
+    @ScriptProperty({
+        "networkAccept \"nukleus://target/streams/kafka\"",
+        "applicationConnectWindow \"200\""
+    })
+    public void shouldNotDeliverSecondFragmentFromADifferentMessageFromAnotherPartition()
             throws Exception
     {
         k3po.finish();

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkTopicPartitionTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkTopicPartitionTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.NavigableSet;
+import java.util.TreeSet;
+
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Rule;
+import org.junit.Test;
+import org.reaktivity.nukleus.kafka.internal.stream.NetworkConnectionPool.NetworkTopicPartition;
+
+public final class NetworkTopicPartitionTest
+{
+    private final NavigableSet<NetworkTopicPartition> partitions = new TreeSet<>();
+
+    @Rule
+    public JUnitRuleMockery context = new JUnitRuleMockery();
+
+    @Test
+    public void shouldFindFloor()
+    {
+         NetworkTopicPartition partition;
+         partition = new NetworkTopicPartition();
+         partition.id = 0;
+         partition.offset = 6789;
+         partitions.add(partition);
+         partition = new NetworkTopicPartition();
+         partition.id = 0;
+         partition.offset = 142706;
+         partitions.add(partition);
+
+         partition = new NetworkTopicPartition();
+         partition.id = 1;
+         partition.offset = 3574;
+         partitions.add(partition);
+         partition = new NetworkTopicPartition();
+         partition.id = 1;
+         partition.offset = 168550;
+         partitions.add(partition);
+
+         partition = new NetworkTopicPartition();
+         partition.id = 2;
+         partition.offset = 16968;
+         partitions.add(partition);
+         partition = new NetworkTopicPartition();
+         partition.id = 2;
+         partition.offset = 0;
+         partitions.add(partition);
+         partition = new NetworkTopicPartition();
+         partition.id = 2;
+         partition.offset = 168162;
+         partitions.add(partition);
+
+         partition = new NetworkTopicPartition();
+         partition.id = 3;
+         partition.offset = 426618;
+         partitions.add(partition);
+
+         NetworkTopicPartition  candidate = new NetworkTopicPartition();
+         candidate.id = 2;
+         candidate.offset = 0;
+         NetworkTopicPartition first = partitions.floor(candidate);
+
+         assertEquals(2, first.id);
+         assertEquals(0, first.offset);
+
+         candidate.id = 1;
+         candidate.offset = 3573;
+         first = partitions.floor(candidate);
+
+
+         assertEquals(0, first.id);
+         assertEquals(142706, first.offset);
+    }
+
+}


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/59

 Fixes include:
- handle fetch response with truncation inside record length field
- handle changed partition response ordering when refetching a partially delivered message (was causing IndexOutOfBoundsException)
- adjust offsets correctly in ClientAcceptStream.dispatch and flush
-  adjust offsets correctly in NetworkTopic.satisfyPartitionRequestsFromCache
- avoid mutating a partition in NetworkTopic.partitions when handling case of topic recreated (instead remove and add the partition to preserve ordering)