### PR TITLE
Fixes to fetch response decoder to  avoid accidentally skipping messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkout issue_603_skipped_messages
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
-  - cd nukleus-kafka.spec
-  - git checkout issue_603_skipped_messages
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.22</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.72</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.59</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.22</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.73</nukleus.kafka.spec.version>
     <reaktor.version>0.59</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/FetchResponseDecoder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/FetchResponseDecoder.java
@@ -97,7 +97,6 @@ public class FetchResponseDecoder implements ResponseDecoder
     private long nextFetchAt;
     private int recordCount;
     private long firstOffset;
-    private int lastOffsetDelta;
     private long firstTimestamp;
 
     private final SkipBytesDecoderState skipBytesDecoderState = new SkipBytesDecoderState();
@@ -427,7 +426,6 @@ public class FetchResponseDecoder implements ResponseDecoder
             else
             {
                 firstOffset = recordBatch.firstOffset();
-                lastOffsetDelta = recordBatch.lastOffsetDelta();
                 firstTimestamp = recordBatch.firstTimestamp();
                 recordCount = recordBatch.recordCount();
                 nextFetchAt = firstOffset;
@@ -451,17 +449,6 @@ public class FetchResponseDecoder implements ResponseDecoder
         int newOffset = offset;
         if (recordSetBytesRemaining == 0)
         {
-            if (recordBatchBytesRemaining > 0 || recordCount > 0)
-            {
-                //  record batch truncated at a record boundary, make sure we attempt to fetch the missing records
-                nextFetchAt = firstOffset + lastOffsetDelta;
-            }
-            else
-            {
-                // If there are deleted records, the last offset reported on the record batch may exceed the
-                // offset of the last record in the batch. So we must use this to make sure we continue to advance.
-                nextFetchAt = firstOffset + lastOffsetDelta + 1;
-            }
             messageDispatcher.flush(partition, requestedOffset, nextFetchAt);
             decoderState = this::decodePartitionResponse;
         }
@@ -486,10 +473,11 @@ public class FetchResponseDecoder implements ResponseDecoder
             }
             if (recordSize > recordSetBytesRemaining)
             {
-                // Truncated record at end of batch, make sure we attempt to re-fetch it.
-                // We assume the record batch's lastOffsetDelta is that of this truncated record, because
-                // otherwise it would be impossible to distinguish from deleted records case.
-                nextFetchAt = firstOffset + lastOffsetDelta;
+                // Truncated record at end of batch, make sure we attempt to re-fetch it. Experience shows
+                // the record batch's lastOffsetDelta is that of the last record that would have been in
+                // in the batch had it not been truncated, so we must re-fetch this record using the
+                // the offset of the previous record plus 1 (if there was a previous record) else the
+                // first offset of the record batch.
                 messageDispatcher.flush(partition, requestedOffset, nextFetchAt);
                 skipBytesDecoderState.bytesToSkip = recordSetBytesRemaining;
                 skipBytesDecoderState.nextState = this::decodePartitionResponse;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/FetchResponseDecoder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/FetchResponseDecoder.java
@@ -360,12 +360,6 @@ public class FetchResponseDecoder implements ResponseDecoder
             newOffset = response.limit();
             if (recordSetBytesRemaining == 0)
             {
-                long requestedOffset = getRequestedOffsetForPartition.apply(topicName, partition);
-                if (highWatermark > requestedOffset && errorCode == NONE.errorCode)
-                {
-                    nextFetchAt = requestedOffset + 1;
-                    messageDispatcher.flush(partition, requestedOffset, requestedOffset + 1);
-                }
                 decoderState = this::decodePartitionResponse;
             }
             else if (recordSetBytesRemaining > maxRecordBatchSize)

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
@@ -281,20 +281,6 @@ public class CachingFetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/zero.offset.message/client",
-        "${server}/zero.length.record.batch/server"})
-    @ScriptProperty({
-        "networkAccept \"nukleus://target/streams/kafka\"",
-        "messageOffset 2"
-    })
-    public void shouldSkipZeroLengthRecordBatch() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${route}/client/controller",
         "${client}/compacted.message/client",
         "${server}/compacted.message/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -290,20 +290,6 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/zero.offset.message/client",
-        "${server}/zero.length.record.batch/server"})
-    @ScriptProperty({
-        "networkAccept \"nukleus://target/streams/kafka\"",
-        "messageOffset 2"
-    })
-    public void shouldSkipZeroLengthRecordBatch() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${route}/client/controller",
         "${client}/compacted.message/client",
         "${server}/compacted.message/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -138,4 +138,18 @@ public class FetchLimitsIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/zero.offset.messages.multiple.partitions/client",
+        "${server}/record.set.size.zero.record.too.large/server"})
+    @ScriptProperty({
+        "networkAccept \"nukleus://target/streams/kafka\"",
+        "offsetMessage2 2"
+    })
+    public void shouldSkipRecordLargerThanFetchPartitionMaxBytes() throws Exception
+    {
+        k3po.finish();
+    }
 }


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/60

Contains fixes to the fence response decoder to accommodate observed behavior of the Kafka broker:

-   A record set of size zero  in a partition response with highWaterMark higher than the  requested fetch offset does not necessarily result from a record that was too large to deliver (larger than fetch partition  max bytes) so  we must not increment next offset in this case
- record too large case where the large record is at the requested fetch at:  results in a  size 0 record set in  fetch responses which contain data for other partitions on the topic,  but  when there is no such data  the partition response comes up with the actual record set size and the actual record, even though it exceeds fetch partition max bytes
-  last offset delta  on a  truncated record batch in a fetch response  indicates the last offset of the last record in the batch, irrespective of truncation. It does not  indicate the offset of the truncated record.

