### PR TITLE
Unlimited message cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkout fix_build_failure
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,10 @@
     <k3po.nukleus.ext.version>0.29</k3po.nukleus.ext.version>
 
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
-    <nukleus.version>0.22</nukleus.version>
+    <nukleus.version>develop-SNAPSHOT</nukleus.version>
 
     <nukleus.kafka.spec.version>0.72</nukleus.kafka.spec.version>
-    <reaktor.version>0.59</reaktor.version>
+    <reaktor.version>develop-SNAPSHOT</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,10 @@
     <k3po.nukleus.ext.version>0.29</k3po.nukleus.ext.version>
 
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
-    <nukleus.version>develop-SNAPSHOT</nukleus.version>
+    <nukleus.version>0.23</nukleus.version>
 
     <nukleus.kafka.spec.version>0.73</nukleus.kafka.spec.version>
-    <reaktor.version>develop-SNAPSHOT</reaktor.version>
+    <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.73</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaConfiguration.java
@@ -41,7 +41,7 @@ public class KafkaConfiguration extends Configuration
 
     public static final String MESSAGE_CACHE_BLOCK_CAPACITY_PROPERTY = "nukleus.kafka.message.cache.block.capacity";
 
-    public static final int MESSAGE_CACHE_CAPACITY_DEFAULT = 128 * 1024 * 1024;
+    public static final long MESSAGE_CACHE_CAPACITY_DEFAULT = 128 * 1024 * 1024;
 
     public static final int MESSAGE_CACHE_BLOCK_CAPACITY_DEFAULT = 1024;
 
@@ -68,9 +68,9 @@ public class KafkaConfiguration extends Configuration
         return getInteger(FETCH_PARTITION_MAX_BYTES_PROPERTY, FETCH_PARTITION_MAX_BYTES_DEFAULT);
     }
 
-    public int messageCacheCapacity()
+    public long messageCacheCapacity()
     {
-        return getInteger(MESSAGE_CACHE_CAPACITY_PROPERTY, MESSAGE_CACHE_CAPACITY_DEFAULT);
+        return getLong(MESSAGE_CACHE_CAPACITY_PROPERTY, MESSAGE_CACHE_CAPACITY_DEFAULT);
     }
 
     public int messageCacheBlockCapacity()

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
@@ -50,6 +50,7 @@ import org.reaktivity.nukleus.kafka.internal.types.control.RouteFW;
 public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
 {
     public static final String MESSAGE_CACHE_BUFFER_ACQUIRES = "message.cache.buffer.acquires";
+    public static final String HISTORICAL_FETCHES = "historical.fetches";
     private static final String MESSAGE_CACHE_BUFFER_RELEASES = "message.cache.buffer.releases";
 
     private static final MemoryManager OUT_OF_SPACE_MEMORY_MANAGER = new MemoryManager()

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
@@ -128,7 +128,7 @@ public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
         Function<String, LongSupplier> supplyCounter)
     {
         MemoryManager result;
-        int capacity = kafkaConfig.messageCacheCapacity();
+        long capacity = kafkaConfig.messageCacheCapacity();
         if (capacity == 0)
         {
             result = OUT_OF_SPACE_MEMORY_MANAGER;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaNukleusFactorySpi.java
@@ -141,7 +141,7 @@ public final class KafkaNukleusFactorySpi implements NukleusFactorySpi, Nukleus
                     // TODO: non-deprecated way of getting nukleus's home directory; change name of memory0?
                     .path(kafkaConfig.directory().resolve("kafka").resolve("memory0"))
                     .minimumBlockSize(kafkaConfig.messageCacheBlockCapacity())
-                    .maximumBlockSize(capacity)
+                    .capacity(capacity)
                     .create(true)
                     .build();
             this.memoryLayout = memoryLayout;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManager.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManager.java
@@ -15,7 +15,7 @@
  */
 package org.reaktivity.nukleus.kafka.internal.memory;
 
-import static java.lang.Integer.highestOneBit;
+import static java.lang.Long.highestOneBit;
 import static java.lang.Long.numberOfTrailingZeros;
 import static org.agrona.BitUtil.findNextPositivePowerOfTwo;
 import static org.reaktivity.nukleus.kafka.internal.memory.BTreeFW.EMPTY;
@@ -61,19 +61,9 @@ public class DefaultMemoryManager implements MemoryManager
     public long resolve(
         long address)
     {
-        MutableDirectBuffer memoryBuffer;
-
-        if (address < firstBufferCapacity)
-        {
-            memoryBuffer = memoryBuffers[0];
-        }
-        else
-        {
-            int index = (int) (address >> addressShift);
-            memoryBuffer = memoryBuffers[index];
-            address &= addressMask;
-        }
-
+        int index = (int) (address >> addressShift);
+        MutableDirectBuffer memoryBuffer = memoryBuffers[index];
+        address &= addressMask;
         return memoryBuffer.addressOffset() + address;
     }
 
@@ -145,8 +135,7 @@ public class DefaultMemoryManager implements MemoryManager
             }
         }
 
-        long addressToShift = ((nodeIndex + 1) & ~highestOneBit(nodeIndex + 1));
-        return addressToShift << blockSizeShift << nodeOrder;
+        return ((nodeIndex + 1) & ~highestOneBit(nodeIndex + 1)) << blockSizeShift << nodeOrder;
     }
 
     @Override

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManager.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManager.java
@@ -32,7 +32,6 @@ public class DefaultMemoryManager implements MemoryManager
     private final BTreeFW btreeRO;
 
     private final int blockSizeShift;
-    private final long maximumBlockSize;
     private final int maximumOrder;
 
     private final MutableDirectBuffer[] memoryBuffers;
@@ -51,7 +50,6 @@ public class DefaultMemoryManager implements MemoryManager
         this.memoryBuffers = memoryLayout.memoryBuffers();
         this.metadataBuffer = memoryLayout.metadataBuffer();
         this.blockSizeShift = numberOfTrailingZeros(minimumBlockSize);
-        this.maximumBlockSize = maximumBlockSize;
         this.maximumOrder = numberOfTrailingZeros(maximumBlockSize) - numberOfTrailingZeros(minimumBlockSize);
         this.btreeRO = new BTreeFW(maximumOrder).wrap(metadataBuffer, BTREE_OFFSET, metadataBuffer.capacity() - BTREE_OFFSET);
         firstBufferCapacity = memoryBuffers[0].capacity();
@@ -81,9 +79,9 @@ public class DefaultMemoryManager implements MemoryManager
 
     @Override
     public long acquire(
-        int capacity)
+        final int capacity)
     {
-        if (capacity > this.maximumBlockSize)
+        if (capacity > this.firstBufferCapacity)
         {
             return -1;
         }
@@ -119,7 +117,7 @@ public class DefaultMemoryManager implements MemoryManager
 
         if (node.flag(FULL) || node.flag(SPLIT))
         {
-            return -1;
+            return -1L;
         }
         assert node.order() == allocationOrder;
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManager.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManager.java
@@ -147,7 +147,8 @@ public class DefaultMemoryManager implements MemoryManager
             }
         }
 
-        return ((nodeIndex + 1) & ~highestOneBit(nodeIndex + 1)) << blockSizeShift << nodeOrder;
+        long addressToShift = ((nodeIndex + 1) & ~highestOneBit(nodeIndex + 1));
+        return addressToShift << blockSizeShift << nodeOrder;
     }
 
     @Override

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/memory/MemoryLayout.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/memory/MemoryLayout.java
@@ -41,10 +41,8 @@ public final class MemoryLayout extends Layout
     public static final int BITS_PER_BTREE_NODE = 1 << BITS_PER_BTREE_NODE_SHIFT;
     public static final int MASK_PER_BTREE_NODE = (1 << BITS_PER_BTREE_NODE) - 1;
 
-    public static final int LOCK_OFFSET = 0;
-    public static final int LOCK_SIZE = Long.BYTES;
-    public static final int MINIMUM_BLOCK_SIZE_OFFSET = LOCK_OFFSET + LOCK_SIZE;
-    public static final int MINIMUM_BLOCK_SIZE_SIZE = Long.BYTES;
+    public static final int MINIMUM_BLOCK_SIZE_OFFSET = 0;
+    public static final int MINIMUM_BLOCK_SIZE_SIZE = Integer.BYTES;
     public static final int MAXIMUM_BLOCK_SIZE_OFFSET = MINIMUM_BLOCK_SIZE_OFFSET + MINIMUM_BLOCK_SIZE_SIZE;
     public static final int MAXIMUM_BLOCK_SIZE_SIZE = Long.BYTES;
     public static final int BTREE_OFFSET = MAXIMUM_BLOCK_SIZE_OFFSET + MAXIMUM_BLOCK_SIZE_SIZE;
@@ -171,10 +169,6 @@ public final class MemoryLayout extends Layout
                 metadataSize = BTREE_OFFSET + sizeofBTree(minimumBlockSize, maximumBlockSize);
                 metadataSizeAligned = align(metadataSize, CACHE_LINE_LENGTH);
                 unmap(mappedBootstrap);
-
-                metadataSize = BTREE_OFFSET + sizeofBTree(minimumBlockSize, maximumBlockSize);
-                metadataSizeAligned = align(metadataSize, CACHE_LINE_LENGTH);
-
             }
 
             final MappedByteBuffer mappedMetadata = mapExistingFile(memory, "metadata", 0, metadataSizeAligned);
@@ -202,10 +196,10 @@ public final class MemoryLayout extends Layout
             }
 
             final MutableDirectBuffer[] memoryBuffers = new MutableDirectBuffer[mappedMemoryBuffers.length];
+
             for (int i=0; i < memoryBuffers.length; i++)
             {
                 memoryBuffers[i] = new UnsafeBuffer(mappedMemoryBuffers[i]);
-
             }
 
             return new MemoryLayout(metadataBuffer, memoryBuffers);

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/memory/MemoryLayout.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/memory/MemoryLayout.java
@@ -15,11 +15,10 @@
  */
 package org.reaktivity.nukleus.kafka.internal.memory;
 
-import static java.lang.Integer.numberOfTrailingZeros;
+import static java.lang.Long.numberOfTrailingZeros;
 import static java.lang.Math.max;
+import static java.lang.String.format;
 import static org.agrona.BitUtil.CACHE_LINE_LENGTH;
-import static org.agrona.BitUtil.align;
-import static org.agrona.BitUtil.isPowerOfTwo;
 import static org.agrona.IoUtil.createEmptyFile;
 import static org.agrona.IoUtil.mapExistingFile;
 import static org.agrona.IoUtil.unmap;
@@ -45,27 +44,33 @@ public final class MemoryLayout extends Layout
     public static final int LOCK_OFFSET = 0;
     public static final int LOCK_SIZE = Long.BYTES;
     public static final int MINIMUM_BLOCK_SIZE_OFFSET = LOCK_OFFSET + LOCK_SIZE;
-    public static final int MINIMUM_BLOCK_SIZE_SIZE = Integer.BYTES;
+    public static final int MINIMUM_BLOCK_SIZE_SIZE = Long.BYTES;
     public static final int MAXIMUM_BLOCK_SIZE_OFFSET = MINIMUM_BLOCK_SIZE_OFFSET + MINIMUM_BLOCK_SIZE_SIZE;
-    public static final int MAXIMUM_BLOCK_SIZE_SIZE = Integer.BYTES;
+    public static final int MAXIMUM_BLOCK_SIZE_SIZE = Long.BYTES;
     public static final int BTREE_OFFSET = MAXIMUM_BLOCK_SIZE_OFFSET + MAXIMUM_BLOCK_SIZE_SIZE;
 
+    public static final long MAX_MAPPABLE_BYTES = Integer.MAX_VALUE;
+    public static final int ONE_GB = 0x40000000;
+
     private final AtomicBuffer metadataBuffer;
-    private final MutableDirectBuffer memoryBuffer;
+    private final MutableDirectBuffer[] memoryBuffers;
 
     private MemoryLayout(
         AtomicBuffer metadataBuffer,
-        MutableDirectBuffer memoryBuffer)
+        MutableDirectBuffer[] memoryBuffers)
     {
         this.metadataBuffer = metadataBuffer;
-        this.memoryBuffer = memoryBuffer;
+        this.memoryBuffers = memoryBuffers;
     }
 
     @Override
     public void close()
     {
         unmap(metadataBuffer.byteBuffer());
-        unmap(memoryBuffer.byteBuffer());
+        for (MutableDirectBuffer memoryBuffer : memoryBuffers)
+        {
+            unmap(memoryBuffer.byteBuffer());
+        }
     }
 
     public AtomicBuffer metadataBuffer()
@@ -73,32 +78,37 @@ public final class MemoryLayout extends Layout
         return metadataBuffer;
     }
 
-    public MutableDirectBuffer memoryBuffer()
+    public MutableDirectBuffer[] memoryBuffers()
     {
-        return memoryBuffer;
+        return memoryBuffers;
     }
 
-    public int minimumBlockSize()
+    public long minimumBlockSize()
     {
         return metadataBuffer.getInt(MINIMUM_BLOCK_SIZE_OFFSET);
     }
 
-    public int maximumBlockSize()
+    public long maximumBlockSize()
     {
         return metadataBuffer.getInt(MAXIMUM_BLOCK_SIZE_OFFSET);
     }
 
-    public int capacity()
+    public long capacity()
     {
-        return memoryBuffer.capacity();
+        long capacity = 0;
+        for (MutableDirectBuffer memoryBuffer : memoryBuffers)
+        {
+            capacity += memoryBuffer.capacity();
+        }
+        return capacity;
     }
 
     public static final class Builder extends Layout.Builder<MemoryLayout>
     {
         private Path path;
-        private int capacity;
-        private int minimumBlockSize;
-        private int maximumBlockSize;
+        private long capacity;
+        private long minimumBlockSize;
+        private long maximumBlockSize;
         private boolean create;
 
         public Builder path(
@@ -116,7 +126,7 @@ public final class MemoryLayout extends Layout
         }
 
         public Builder minimumBlockSize(
-            int minimumBlockSize)
+            long minimumBlockSize)
         {
             if (!isPowerOfTwo(minimumBlockSize))
             {
@@ -128,14 +138,19 @@ public final class MemoryLayout extends Layout
         }
 
         public Builder maximumBlockSize(
-            int maximumBlockSize)
+            long maximumBlockSize)
         {
             if (!isPowerOfTwo(maximumBlockSize))
             {
                 throw new IllegalArgumentException("maximum block size MUST be a power of 2");
             }
 
-            this.maximumBlockSize = maximumBlockSize;
+            if (capacity >> Integer.numberOfTrailingZeros(ONE_GB) > Integer.MAX_VALUE)
+            {
+                throw new IllegalStateException("capacity too large, number of 1GB buffers would exceed Integer.MAX_VALUE");
+            }
+
+            this.maximumBlockSize = Math.min(maximumBlockSize, ONE_GB);
             this.capacity = maximumBlockSize;
             return this;
         }
@@ -144,51 +159,106 @@ public final class MemoryLayout extends Layout
         public MemoryLayout build()
         {
             final File memory = path.toFile();
+            long metadataSize;
+            long metadataSizeAligned;
 
             if (create)
             {
-                final int metadataSize = BTREE_OFFSET + sizeofBTree(minimumBlockSize, maximumBlockSize);
-                final int metadataSizeAligned = align(metadataSize, CACHE_LINE_LENGTH);
+                metadataSize = BTREE_OFFSET + sizeofBTree(minimumBlockSize, maximumBlockSize);
+                metadataSizeAligned = align(metadataSize, CACHE_LINE_LENGTH);
+                if (metadataSizeAligned > MAX_MAPPABLE_BYTES)
+                {
+                    throw new IllegalStateException(format(
+                            "BTree size %d exceeds ONE_GB, difference between minimum and maximum block size is too great",
+                            metadataSizeAligned));
+                }
                 CloseHelper.close(createEmptyFile(memory, metadataSizeAligned + capacity));
-
-                final MappedByteBuffer mappedMetadata = mapExistingFile(memory, "metadata", 0, metadataSizeAligned);
-                final MappedByteBuffer mappedMemory = mapExistingFile(memory, "memory", metadataSizeAligned, capacity);
-
-                final AtomicBuffer metadataBuffer = new UnsafeBuffer(mappedMetadata, 0, metadataSize);
-                final MutableDirectBuffer memoryBuffer = new UnsafeBuffer(mappedMemory);
-
-                metadataBuffer.putInt(MINIMUM_BLOCK_SIZE_OFFSET, minimumBlockSize);
-                metadataBuffer.putInt(MAXIMUM_BLOCK_SIZE_OFFSET, maximumBlockSize);
-                return new MemoryLayout(metadataBuffer, memoryBuffer);
             }
             else
             {
                 final MappedByteBuffer mappedBootstrap = mapExistingFile(memory, "bootstrap", 0, BTREE_OFFSET);
                 final DirectBuffer bootstrapBuffer = new UnsafeBuffer(mappedBootstrap);
-                final int minimumBlockSize = bootstrapBuffer.getInt(MINIMUM_BLOCK_SIZE_OFFSET);
-                final int maximumBlockSize = bootstrapBuffer.getInt(MAXIMUM_BLOCK_SIZE_OFFSET);
+                final long minimumBlockSize = bootstrapBuffer.getLong(MINIMUM_BLOCK_SIZE_OFFSET);
+                final long maximumBlockSize = bootstrapBuffer.getLong(MAXIMUM_BLOCK_SIZE_OFFSET);
+                metadataSize = BTREE_OFFSET + sizeofBTree(minimumBlockSize, maximumBlockSize);
+                metadataSizeAligned = align(metadataSize, CACHE_LINE_LENGTH);
                 unmap(mappedBootstrap);
 
-                final int metadataSize = BTREE_OFFSET + sizeofBTree(minimumBlockSize, maximumBlockSize);
-                final int metadataSizeAligned = align(metadataSize, CACHE_LINE_LENGTH);
-                final int capacity = (int) memory.length() - metadataSizeAligned;
+                metadataSize = BTREE_OFFSET + sizeofBTree(minimumBlockSize, maximumBlockSize);
+                metadataSizeAligned = align(metadataSize, CACHE_LINE_LENGTH);
+                capacity = memory.length() - metadataSizeAligned;
 
-                final MappedByteBuffer mappedMetadata = mapExistingFile(memory, "metadata", 0, metadataSize);
-                final MappedByteBuffer mappedMemory = mapExistingFile(memory, "memory", metadataSizeAligned, capacity);
-
-                final AtomicBuffer metadataBuffer = new UnsafeBuffer(mappedMetadata);
-                final MutableDirectBuffer memoryBuffer = new UnsafeBuffer(mappedMemory);
-
-                return new MemoryLayout(metadataBuffer, memoryBuffer);
             }
+
+            final MappedByteBuffer mappedMetadata = mapExistingFile(memory, "metadata", 0, metadataSizeAligned);
+            final AtomicBuffer metadataBuffer = new UnsafeBuffer(mappedMetadata, 0, (int) metadataSize);
+            metadataBuffer.putLong(MINIMUM_BLOCK_SIZE_OFFSET, minimumBlockSize);
+            metadataBuffer.putLong(MAXIMUM_BLOCK_SIZE_OFFSET, maximumBlockSize);
+
+            final MappedByteBuffer[] mappedMemoryBuffers;
+            long start = metadataSizeAligned;
+
+            if (capacity <= ONE_GB)
+            {
+                mappedMemoryBuffers = new MappedByteBuffer[1];
+                mappedMemoryBuffers[0] = mapExistingFile(memory, "memory", start, capacity);
+            }
+            else
+            {
+                int buffersNeeded = (int) (capacity >> Integer.numberOfTrailingZeros(ONE_GB));
+                mappedMemoryBuffers = new MappedByteBuffer[buffersNeeded];
+                for (int i = 0; i < buffersNeeded; i++)
+                {
+                    mappedMemoryBuffers[i] = mapExistingFile(memory, "memory" + i, start, ONE_GB);
+                    start += ONE_GB;
+                }
+            }
+
+            final MutableDirectBuffer[] memoryBuffers = new MutableDirectBuffer[mappedMemoryBuffers.length];
+            for (int i=0; i < memoryBuffers.length; i++)
+            {
+                memoryBuffers[i] = new UnsafeBuffer(mappedMemoryBuffers[i]);
+
+            }
+
+            return new MemoryLayout(metadataBuffer, memoryBuffers);
         }
 
-        private static int sizeofBTree(
-            int minimumBlockSize,
-            int maximumBlockSize)
+        private static long sizeofBTree(
+            long minimumBlockSize,
+            long maximumBlockSize)
         {
             int orderCount = numberOfTrailingZeros(maximumBlockSize) - numberOfTrailingZeros(minimumBlockSize) + 1;
-            return align(max(1 << orderCount << BITS_PER_BTREE_NODE_SHIFT >> BITS_PER_BYTE_SHIFT, Byte.BYTES), Byte.BYTES);
+            return align(max(1L << orderCount << BITS_PER_BTREE_NODE_SHIFT >> BITS_PER_BYTE_SHIFT, Byte.BYTES), Byte.BYTES);
         }
+
+        /**
+         * Align a value to the next multiple up of alignment.
+         * If the value equals an alignment multiple then it is returned unchanged.
+         * <p>
+         * This method executes without branching. This code is designed to be use in the fast path and should not
+         * be used with negative numbers. Negative numbers will result in undefined behaviour.
+         *
+         * @param value     to be aligned up.
+         * @param alignment to be used.
+         * @return the value aligned to the next boundary.
+         */
+        private static long align(final long value, final long alignment)
+        {
+            return (value + (alignment - 1)) & ~(alignment - 1);
+        }
+
+        /**
+         * Is a value a positive power of two.
+         *
+         * @param value to be checked.
+         * @return true if the number is a positive power of two otherwise false.
+         */
+        private static boolean isPowerOfTwo(final long value)
+        {
+            return value > 0 && ((value & (~value + 1)) == value);
+        }
+
+
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactoryBuilder.java
@@ -139,6 +139,6 @@ public final class ClientStreamFactoryBuilder implements StreamFactoryBuilder
         final MemoryManager memoryManager = supplyMemoryManager.apply(supplyCounter);
 
         return new ClientStreamFactory(config, router, writeBuffer, bufferPool, memoryManager, supplyStreamId, supplyTrace,
-                supplyCorrelationId, correlations, connectionPools, connectPoolFactoryConsumer);
+                supplyCorrelationId, supplyCounter, correlations, connectionPools, connectPoolFactoryConsumer);
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -46,6 +46,7 @@ import java.util.function.Function;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
 import java.util.function.IntToLongFunction;
+import java.util.function.LongSupplier;
 
 import org.agrona.BitUtil;
 import org.agrona.DirectBuffer;
@@ -59,6 +60,7 @@ import org.agrona.collections.LongArrayList;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.reaktivity.nukleus.buffer.BufferPool;
 import org.reaktivity.nukleus.function.MessageConsumer;
+import org.reaktivity.nukleus.kafka.internal.KafkaNukleusFactorySpi;
 import org.reaktivity.nukleus.kafka.internal.cache.CompactedPartitionIndex;
 import org.reaktivity.nukleus.kafka.internal.cache.DefaultPartitionIndex;
 import org.reaktivity.nukleus.kafka.internal.cache.MessageCache;
@@ -130,6 +132,11 @@ public final class NetworkConnectionPool
 
     private static final int KAFKA_SERVER_DEFAULT_DELETE_RETENTION_MS = 86400000;
     private static final PartitionIndex DEFAULT_PARTITION_INDEX = new DefaultPartitionIndex();
+
+    private static final LongSupplier NO_COUNTER = () ->
+    {
+        return 0L;
+    };
 
     private static final DecoderMessageDispatcher NOOP_DISPATCHER = new DecoderMessageDispatcher()
     {
@@ -263,6 +270,7 @@ public final class NetworkConnectionPool
 
     private final List<NetworkTopicPartition> partitionsWorkList = new ArrayList<NetworkTopicPartition>();
     private final LongArrayList offsetsWorkList = new LongArrayList();
+    private final LongSupplier historicalFetches;
     private int nextAttachId;
 
     NetworkConnectionPool(
@@ -273,6 +281,7 @@ public final class NetworkConnectionPool
         int fetchPartitionMaxBytes,
         BufferPool bufferPool,
         MessageCache messageCache,
+        Function<String, LongSupplier> supplyCounter,
         boolean forceProactiveMessageCache)
     {
         this.clientStreamFactory = clientStreamFactory;
@@ -283,6 +292,8 @@ public final class NetworkConnectionPool
         this.bufferPool = bufferPool;
         this.messageCache = messageCache;
         this.forceProactiveMessageCache = forceProactiveMessageCache;
+        this.historicalFetches = supplyCounter.apply(
+                format("%s.%s.%d", KafkaNukleusFactorySpi.HISTORICAL_FETCHES, networkName, networkRef));
         this.encodeBuffer = new UnsafeBuffer(new byte[clientStreamFactory.bufferPool.slotCapacity()]);
         this.topicsByName = new LinkedHashMap<>();
         this.topicMetadataByName = new HashMap<>();
@@ -912,12 +923,17 @@ public final class NetworkConnectionPool
         Map<String, long[]> requestedFetchOffsetsByTopic = new HashMap<>();
         final ResponseDecoder fetchResponseDecoder;
 
-        private AbstractFetchConnection(BrokerMetadata broker)
+        private final LongSupplier fetches;
+
+        private AbstractFetchConnection(
+            BrokerMetadata broker,
+            LongSupplier fetches)
         {
             super();
             this.brokerId = broker.nodeId;
             this.host = broker.host;
             this.port = broker.port;
+            this.fetches = fetches;
             fetchResponseDecoder = new FetchResponseDecoder(
                     this::getTopicDispatcher,
                     this::getRequestedOffset,
@@ -1042,6 +1058,8 @@ public final class NetworkConnectionPool
                     .wrap(NetworkConnectionPool.this.encodeBuffer, encodeOffset, encodeLimit)
                     .set((b, o, m) -> m - o)
                     .build();
+
+                fetches.getAsLong();
 
                 NetworkConnectionPool.this.clientStreamFactory.doData(networkTarget, networkId,
                         networkRequestPadding, payload);
@@ -1317,7 +1335,7 @@ public final class NetworkConnectionPool
     {
         LiveFetchConnection(BrokerMetadata broker)
         {
-            super(broker);
+            super(broker, NO_COUNTER);
         }
 
         @Override
@@ -1408,7 +1426,7 @@ public final class NetworkConnectionPool
     {
         private HistoricalFetchConnection(BrokerMetadata broker)
         {
-            super(broker);
+            super(broker, historicalFetches);
         }
 
         @Override

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -133,10 +133,7 @@ public final class NetworkConnectionPool
     private static final int KAFKA_SERVER_DEFAULT_DELETE_RETENTION_MS = 86400000;
     private static final PartitionIndex DEFAULT_PARTITION_INDEX = new DefaultPartitionIndex();
 
-    private static final LongSupplier NO_COUNTER = () ->
-    {
-        return 0L;
-    };
+    private static final LongSupplier NO_COUNTER = Long.valueOf(0L)::longValue;
 
     private static final DecoderMessageDispatcher NOOP_DISPATCHER = new DecoderMessageDispatcher()
     {

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/memory/ConfigureMemoryLayout.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/memory/ConfigureMemoryLayout.java
@@ -24,6 +24,6 @@ import java.lang.annotation.Target;
 @Target({ ElementType.METHOD })
 public @interface ConfigureMemoryLayout
 {
-    int capacity();
+    long capacity();
     int smallestBlockSize();
 }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManagerRule.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManagerRule.java
@@ -46,7 +46,7 @@ public class DefaultMemoryManagerRule implements TestRule
             ConfigureMemoryLayout configures = description.getTestClass()
                     .getDeclaredMethod(testMethod)
                     .getAnnotation(ConfigureMemoryLayout.class);
-            mlb.maximumBlockSize(configures.capacity())
+            mlb.capacity(configures.capacity())
                .minimumBlockSize(configures.smallestBlockSize())
                .create(true);
         }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManagerTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManagerTest.java
@@ -226,11 +226,7 @@ public class DefaultMemoryManagerTest
         }
         assertEquals(expectedNumberOfAddresses, addresses.size());
 
-        for (int i=0; i < addresses.size(); i++)
-        {
-            memoryManager.release(addresses.get(i), allocationSize);
-        }
-        //addresses.forEach(a -> memoryManager.release(a, allocationSize));
+        addresses.forEach(a -> memoryManager.release(a, allocationSize));
 
         memoryManagerRule.assertReleased();
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManagerTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/memory/DefaultMemoryManagerTest.java
@@ -152,7 +152,7 @@ public class DefaultMemoryManagerTest
 
     @Test
     @ConfigureMemoryLayout(capacity = GB_1, smallestBlockSize = KB)
-    public void shouldAllocateAndReleaseMBlocks1GBCache()
+    public void shouldAllocateAndReleaseBlocks1GBCache()
     {
         final MemoryManager memoryManager = memoryManagerRule.memoryManager();
         memoryManagerRule.assertReleased();

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/memory/MemoryLayoutTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/memory/MemoryLayoutTest.java
@@ -38,13 +38,13 @@ public class MemoryLayoutTest
         MemoryLayout layout = builder
                .create(true)
                .minimumBlockSize(BYTES_64)
-               .maximumBlockSize(GB_2)
+               .capacity(GB_2)
                .build();
         assertEquals(2, layout.memoryBuffers().length);
         assertEquals(GB_1, layout.memoryBuffers()[0].capacity());
         assertEquals(GB_1, layout.memoryBuffers()[1].capacity());
         assertEquals(BYTES_64, layout.minimumBlockSize());
-        assertEquals(GB_2, layout.maximumBlockSize());
+        assertEquals(GB_2, layout.capacity());
     }
 
     @Test
@@ -53,7 +53,7 @@ public class MemoryLayoutTest
         MemoryLayout layout = builder
                .create(true)
                .minimumBlockSize(BYTES_64)
-               .maximumBlockSize(GB_1)
+               .capacity(GB_1)
                .build();
         assertEquals(1, layout.memoryBuffers().length);
         assertEquals(GB_1, layout.memoryBuffers()[0].capacity());

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/memory/MemoryLayoutTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/memory/MemoryLayoutTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.memory;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+public class MemoryLayoutTest
+{
+    private static final int GB_1 = 1024 * 1024 * 1024;
+    private static final long GB_2 = 2L * GB_1;
+    private static final int BYTES_64 = 64;
+
+    final Path outputFile = new File("target/nukleus-itests/memory0").toPath();
+    MemoryLayout.Builder builder = new MemoryLayout.Builder()
+            .path(outputFile);
+
+    @Test
+    public void shouldCreateLayoutWithCapacityGreaterThanOneGB()
+    {
+        MemoryLayout layout = builder
+               .create(true)
+               .minimumBlockSize(BYTES_64)
+               .maximumBlockSize(GB_2)
+               .build();
+        assertEquals(2, layout.memoryBuffers().length);
+        assertEquals(GB_1, layout.memoryBuffers()[0].capacity());
+        assertEquals(GB_1, layout.memoryBuffers()[1].capacity());
+        assertEquals(BYTES_64, layout.minimumBlockSize());
+        assertEquals(GB_2, layout.maximumBlockSize());
+    }
+
+    @Test
+    public void shouldCreateLayoutWithCapacityOneGB()
+    {
+        MemoryLayout layout = builder
+               .create(true)
+               .minimumBlockSize(BYTES_64)
+               .maximumBlockSize(GB_1)
+               .build();
+        assertEquals(1, layout.memoryBuffers().length);
+        assertEquals(GB_1, layout.memoryBuffers()[0].capacity());
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -788,6 +788,10 @@ public class FetchIT
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveMessageMatchingAnyOccurrenceOfARepeatedHeader() throws Exception
     {
+        k3po.start();
+        k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
+        awaitWindowFromClient();
+        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
         k3po.finish();
     }
 


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/61 (to fix an occasional build failure, unrelated to the other changes in this PR)

Added support for arbitrarily large message cache. MemoryLayout assigns multiple memory buffers if needed,  all buffers except the last being of size 1 GB. There is still only one metadata tree and metadata buffer. All buffers are mapped to the same file.

Also added counters for historical fetches, one per Kafka broker network. Example output:
```
java -Dreaktor.streams.buffer.capacity=0x2000000 -Dreaktor.throttle.buffer.capacity=0x200000 -jar command-log.jar -t counters -d shm | tee counters.txt |grep kafka

kafka-sse.routes 1
kafka-sse.acquires 0
kafka-sse.releases 0
kafka.routes 1
kafka.acquires 0
kafka.releases 0
kafka.message.cache.buffer.acquires 1260602
kafka.historical.fetches.tcp.1 30223
```