### PR TITLE
Streaming topics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
-  - cd nukleus-kafka.spec
-  - git checkout streaming_topics
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - rm ~/.m2/settings.xml
   - git clone https://github.com/cmebarrow/nukleus-kafka.spec
   - cd nukleus-kafka.spec
-  - git checkout fix_build_failure
+  - git checkout streaming_topics
   - mvn clean install -DskipTests
   - cd ..
 jdk:

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.76</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.74</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1989,7 +1989,8 @@ public final class NetworkConnectionPool
             candidate.offset = fetchOffset;
             NetworkTopicPartition partition = partitions.floor(candidate);
 
-            if (fetchOffset == MAX_OFFSET && partition != null && partition.isHighWaterMark())
+            if (fetchOffset == MAX_OFFSET &&
+                partition != null && partition.id == candidate.id && partition.isHighWaterMark())
             {
                 // Attach to live stream
                 candidate.offset = partition.offset;

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
@@ -133,7 +133,7 @@ public class BootstrapIT
     @Test
     @Specification({
         "${control}/route/client/controller",
-        "${client}/no.offsets.message/client",
+        "${client}/zero.offset.message/client",
         "${server}/zero.offset.message/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldNotBootstrapWhenTopicBootstrapIsEnabledButTopicIsNotCompacted() throws Exception

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
@@ -638,10 +638,10 @@ public class CachingFetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/fetch.key.no.offsets.message/client",
-        "${server}/fetch.key.zero.offset.first.matches/server"})
+        "${client}/fetch.key.unspecified.offset.message/client",
+        "${server}/fetch.key.high.water.mark.offset.first.matches/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldReceiveMessageMatchingFetchKeyFirstWithZeroLengthOffsetsArray() throws Exception
+    public void shouldReceiveLiveMessageMatchingFetchKey() throws Exception
     {
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
@@ -903,19 +903,6 @@ public class CachingFetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/no.offsets.message/client",
-        "${server}/zero.offset.message/server" })
-    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldReceiveMessageAtZeroOffsetWhenEmptyOffsetsArray() throws Exception
-    {
-        k3po.start();
-        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${route}/client/controller",
         "${client}/zero.offset.and.reset/client",
         "${server}/zero.offset.message/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -443,6 +443,17 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/unspecified.offset/client",
+        "${server}/compacted.zero.offset/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldStartFetchingAtOffsetZeroForCompactedTopicClientOffsetUnspecified() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/distinct.offset.messagesets.fanout/client",
         "${server}/distinct.offset.messagesets.fanout/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
@@ -684,10 +695,10 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/fetch.key.no.offsets.message/client",
-        "${server}/fetch.key.zero.offset.first.matches/server"})
+        "${client}/fetch.key.unspecified.offset.message/client",
+        "${server}/fetch.key.high.water.mark.offset.first.matches/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldReceiveMessageMatchingFetchKeyFirstWithZeroLengthOffsetsArray() throws Exception
+    public void shouldReceiveLiveMessageMatchingFetchKey() throws Exception
     {
         k3po.finish();
     }
@@ -1043,6 +1054,34 @@ public class FetchIT
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveMessagesAtZeroOffset() throws Exception
     {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/unspecified.offset/client",
+        "${server}/high.water.mark.offset/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldAttachAtHighWaterMarkOffsetForStreamingTopic() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/unspecified.offset.multiple.topics/client",
+        "${server}/high.water.mark.offset.multiple.topics/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldAttachAtHighWaterMarkOffsetForStreamingTopics() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("FIRST_FETCH_REQUEST_RECEIVED");
+        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
+        k3po.awaitBarrier("CLIENT_THREE_CONNECTED");
+        awaitWindowFromClient();
+        k3po.notifyBarrier("WRITE_FIRST_FETCH_RESPONSE");
         k3po.finish();
     }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -1050,8 +1050,23 @@ public class FetchIT
         "${client}/unspecified.offset/client",
         "${server}/high.water.mark.offset/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldAttachAtHighWaterMarkOffsetForStreamingTopic() throws Exception
+    public void shouldFetchFromHighWaterMarkOffsetForStreamingTopic() throws Exception
     {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/unspecified.offset.fanout.messages/client",
+        "${server}/high.water.mark.offset.messages/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldFanoutStreamingMessagesWithSingleListOffsetsRequest() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
+        awaitWindowFromClient();
+        k3po.notifyBarrier("WRITE_SECOND_FETCH_RESPONSE");
         k3po.finish();
     }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -997,19 +997,6 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/no.offsets.message/client",
-        "${server}/zero.offset.message/server" })
-    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldReceiveMessageAtZeroOffsetWhenEmptyOffsetsArray() throws Exception
-    {
-        k3po.start();
-        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${route}/client/controller",
         "${client}/zero.offset.and.reset/client",
         "${server}/zero.offset.message/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
@@ -1070,7 +1057,7 @@ public class FetchIT
 
     @Test
     @Specification({
-        "${route}/client/controller",
+        "${routeAnyTopic}/client/controller",
         "${client}/unspecified.offset.multiple.topics/client",
         "${server}/high.water.mark.offset.multiple.topics/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
@@ -1080,6 +1067,8 @@ public class FetchIT
         k3po.awaitBarrier("FIRST_FETCH_REQUEST_RECEIVED");
         k3po.notifyBarrier("CONNECT_CLIENT_TWO");
         k3po.awaitBarrier("CLIENT_THREE_CONNECTED");
+        awaitWindowFromClient();
+        k3po.notifyBarrier("UNSUBSCRIBE_CLIENT_ONE");
         awaitWindowFromClient();
         k3po.notifyBarrier("WRITE_FIRST_FETCH_RESPONSE");
         k3po.finish();

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -1047,8 +1047,32 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/specified.then.unspecified.offset.messages/client",
-        "${server}/specified.offset.then.high.water.mark.messages/server"})
+        "${client}/live.then.specified.offset.then.live.messages/client",
+        "${server}/live.then.specified.offset.then.live.messages/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveLiveHistoricalThenLiveMessagesFromStreamingTopic() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("FIRST_FETCH_REQUEST_RECEIVED");
+        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
+        k3po.awaitBarrier("HISTORICAL_REQUEST_RECEIVED");
+        k3po.notifyBarrier("WRITE_FIRST_FETCH_RESPONSE");
+        k3po.awaitBarrier("CLIENT_ONE_DETACHED");
+        k3po.notifyBarrier("WRITE_HISTORICAL_RESPONSE");
+        k3po.awaitBarrier("CLIENT_TWO_RECEIVED_MESSAGE");
+        k3po.notifyBarrier("WRITE_SECOND_FETCH_RESPONSE");
+        k3po.awaitBarrier("THIRD_FETCH_REQUEST_RECEIVED");
+        k3po.notifyBarrier("CONNECT_CLIENT_THREE");
+        awaitWindowFromClient();
+        k3po.notifyBarrier("WRITE_THIRD_FETCH_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/specified.offset.then.live.messages/client",
+        "${server}/specified.offset.then.live.messages/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveHistoricalThenLiveMessagesFromStreamingTopic() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -1047,6 +1047,25 @@ public class FetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/specified.then.unspecified.offset.messages/client",
+        "${server}/specified.offset.then.high.water.mark.messages/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveHistoricalThenLiveMessagesFromStreamingTopic() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("FIRST_FETCH_REQUEST_RECEIVED");
+        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
+        k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
+        awaitWindowFromClient();
+        k3po.awaitBarrier("HISTORICAL_FETCH_REQUEST_RECEIVED");
+        k3po.notifyBarrier("WRITE_FIRST_FETCH_RESPONSE");
+        k3po.notifyBarrier("WRITE_HISTORICAL_FETCH_RESPONSE");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/unspecified.offset/client",
         "${server}/high.water.mark.offset/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/63

### Functionality

Subscribing to a non-compacted topic with no specified offsets (zero length offsets array in BEGIN extension) causes the client to receive only live messages, that is messages produced after the client connected. 

### Implementation Strategy

- [x] In private NetworkConnectionPool.doAttach, if offsets is 0 length array, set all to Long.MAX_VALUE
- [x] In NetworkTopic.attachToPartition, if this partition is flagged as live, attach to the highest NetworkTopicPartition and call topic.dispatcher.adjustOffset to flip the offset from Long.MAX_VALUE to its offset, else add a new ceiling at Long.MAX_VALUE and flag the partition as live
- [x] In LiveFetchConnection.addTopicToRequest, if live offset is Long.MAX_VALUE, do not add the partition request, instead do as in partitionResponseErrorHandler for offset out of range condition, setting the bad offset in the topic metadata to Long.MAX_VALUE to force a list offsets request to be done
- [x]  In doListOffsetsRequest:  request high watermark (next) offset instead of earliest if bad offset is Long.MAX_VALUE
- [x] When processing list offsets response, call topic.dispatcher.adjustOffset to flip the offset from Long.MAX_VALUE to the actual live (next) offset, and flip the offset on the NetworkTopicPartition 