### PR TITLE
Progress handler diagnostics

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -76,6 +76,11 @@ public final class ClientStreamFactory implements StreamFactory
         .wrap(new UnsafeBuffer(new byte[4]), 0, 4)
         .build();
 
+    private static final PartitionProgressHandler NOOP_PROGRESS_HANDLER = (p, f, n) ->
+    {
+
+    };
+
     private final UnsafeBuffer workBuffer1 = new UnsafeBuffer(EMPTY_BYTE_ARRAY);
     private final UnsafeBuffer workBuffer2 = new UnsafeBuffer(EMPTY_BYTE_ARRAY);
 
@@ -564,6 +569,7 @@ public final class ClientStreamFactory implements StreamFactory
         {
             budget.leaveGroup();
             doAbort(applicationReply, applicationReplyId);
+            progressHandler = NOOP_PROGRESS_HANDLER;
             networkPool.doDetach(networkAttachId, fetchOffsets);
             networkAttachId = UNATTACHED;
         }
@@ -942,10 +948,11 @@ public final class ClientStreamFactory implements StreamFactory
         private void handleReset(
             ResetFW reset)
         {
+            doReset(applicationThrottle, applicationId);
+            budget.leaveGroup();
+            progressHandler = NOOP_PROGRESS_HANDLER;
             networkPool.doDetach(networkAttachId, fetchOffsets);
             networkAttachId = UNATTACHED;
-            budget.leaveGroup();
-            doReset(applicationThrottle, applicationId);
         }
 
         private int writeableBytes()

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -2071,7 +2071,7 @@ public final class NetworkConnectionPool
             candidate.id = partitionId;
             candidate.offset = fetchOffset;
             NetworkTopicPartition partition = partitions.floor(candidate);
-            if (partition == null || partition.id != candidate.id || partition.offset == candidate.offset)
+            if (partition == null || partition.id != candidate.id || partition.offset != candidate.offset)
             {
                 throw new IllegalStateException(
                    format("floor gave %s, expected {id=%d, offset=%d}; topic=%s",


### PR DESCRIPTION
- Altered NetworkTopic doDetach and handleProgress methods to immediately thrown an exception with a diagnostic message when incorrect partitions state is detected
- Altered ClientAcceptStream to set a null progress handler before detaching, to ensure an exception during detach will not cause a cascade of other exceptions