### PR TITLE
Enhanced handling for unknown topic, topic recreation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkout missing_topic
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
-  - cd nukleus-kafka.spec
-  - git checkout missing_topic
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.77</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,7 @@
         <version>2.19.1</version>
         <configuration>
           <argLine>@{argLine}</argLine>
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.81</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/Backoff.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/Backoff.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import static java.lang.String.format;
+
+public class Backoff
+{
+    private final int minimum;
+    private final int maximum;
+
+    Backoff(
+        int minimum,
+        int maximum)
+    {
+        this.minimum = minimum;
+        this.maximum = maximum;
+    }
+
+    public int next(
+        int tries)
+    {
+        int candidate = minimum;
+        if (tries < 32)
+        {
+            candidate <<= tries;
+            System.out.format("%d << %d = %d\n", minimum, tries, candidate);
+        }
+        return candidate <= 0 || candidate == minimum ? maximum : Math.min(candidate, maximum);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Backoff: minimum %d maximum=%d", minimum, maximum);
+    }
+
+}

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/Backoff.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/Backoff.java
@@ -28,7 +28,7 @@ public class Backoff
         int maximum)
     {
         assert minimum > 0;
-        assert maximum > minimum;
+        assert maximum >= minimum;
         this.minimum = minimum;
         this.maximum = maximum;
         this.maximumTries = Integer.numberOfLeadingZeros(minimum) - 1;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/Backoff.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/Backoff.java
@@ -21,25 +21,28 @@ public class Backoff
 {
     private final int minimum;
     private final int maximum;
+    private final int maximumTries;
 
     Backoff(
         int minimum,
         int maximum)
     {
+        assert minimum > 0;
+        assert maximum > minimum;
         this.minimum = minimum;
         this.maximum = maximum;
+        this.maximumTries = Integer.numberOfLeadingZeros(minimum) - 1;
     }
 
     public int next(
         int tries)
     {
-        int candidate = minimum;
-        if (tries < 32)
+        int candidate = maximum;
+        if (tries < maximumTries)
         {
-            candidate <<= tries;
-            System.out.format("%d << %d = %d\n", minimum, tries, candidate);
+            candidate = minimum << tries;
         }
-        return candidate <= 0 || candidate == minimum ? maximum : Math.min(candidate, maximum);
+        return Math.min(candidate, maximum);
     }
 
     @Override

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcher.java
@@ -41,13 +41,14 @@ public class BroadcastMessageDispatcher implements MessageDispatcher
     }
 
     @Override
-    public void detach()
+    public void detach(
+        boolean reattach)
     {
         //  Avoid iterator allocation
         for (int i = 0; i < dispatchers.size(); i++)
         {
             MessageDispatcher dispatcher = dispatchers.get(i);
-            dispatcher.detach();
+            dispatcher.detach(reattach);
         }
     }
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -60,6 +60,7 @@ import org.reaktivity.nukleus.kafka.internal.types.stream.DataFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.EndFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.KafkaBeginExFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.KafkaDataExFW;
+import org.reaktivity.nukleus.kafka.internal.types.stream.KafkaEndExFW;
 import org.reaktivity.nukleus.kafka.internal.types.KafkaHeaderFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.ResetFW;
 import org.reaktivity.nukleus.kafka.internal.types.stream.WindowFW;
@@ -71,12 +72,9 @@ import org.reaktivity.nukleus.stream.StreamFactory;
 
 public final class ClientStreamFactory implements StreamFactory
 {
-    static final long UNSET = -1;
+    private static final long UNSET = -1;
 
-    static final ListFW<KafkaHeaderFW> EMPTY_KAFKA_HEADERS =
-        new ListFW.Builder<KafkaHeaderFW.Builder, KafkaHeaderFW>(new KafkaHeaderFW.Builder(), new KafkaHeaderFW())
-        .wrap(new UnsafeBuffer(new byte[4]), 0, 4)
-        .build();
+    private static final long[] ZERO_OFFSETS = new long[] {0L};
 
     private static final PartitionProgressHandler NOOP_PROGRESS_HANDLER = (p, f, n) ->
     {
@@ -104,6 +102,7 @@ public final class ClientStreamFactory implements StreamFactory
     private final AbortFW.Builder abortRW = new AbortFW.Builder();
 
     private final KafkaDataExFW.Builder dataExRW = new KafkaDataExFW.Builder();
+    private final KafkaEndExFW.Builder endExRW = new KafkaEndExFW.Builder();
 
     private final WindowFW.Builder windowRW = new WindowFW.Builder();
     private final ResetFW.Builder resetRW = new ResetFW.Builder();
@@ -343,14 +342,39 @@ public final class ClientStreamFactory implements StreamFactory
 
     void doEnd(
         final MessageConsumer target,
-        final long targetId)
+        final long targetId,
+        final long[] offsets)
     {
         final EndFW end = endRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                 .streamId(targetId)
                 .trace(supplyTrace.getAsLong())
+                .extension(b -> b.set(visitKafkaEndEx(offsets)))
                 .build();
 
         target.accept(end.typeId(), end.buffer(), end.offset(), end.sizeof());
+    }
+
+    private Flyweight.Builder.Visitor visitKafkaEndEx(
+        long[] fetchOffsets)
+    {
+        return (b, o, l) ->
+        {
+            return endExRW.wrap(b, o, l)
+                    .fetchOffsets(a ->
+                    {
+                        if (fetchOffsets != null)
+                        {
+                        for (int i=0; i < fetchOffsets.length; i++)
+                            {
+                                final long offset = fetchOffsets[i];
+                                a.item(p -> p.set(offset));
+
+                            }
+                        }
+                    })
+                    .build()
+                    .sizeof();
+        };
     }
 
     void doAbort(
@@ -574,13 +598,21 @@ public final class ClientStreamFactory implements StreamFactory
         }
 
         @Override
-        public void detach()
+        public void detach(
+            boolean reattach)
         {
             budget.leaveGroup();
-            doAbort(applicationReply, applicationReplyId);
             progressHandler = NOOP_PROGRESS_HANDLER;
             networkPool.doDetach(networkAttachId, fetchOffsets);
             networkAttachId = UNATTACHED;
+            if (reattach)
+            {
+                doEnd(applicationReply, applicationReplyId, ZERO_OFFSETS);
+            }
+            else
+            {
+                doAbort(applicationReply, applicationReplyId);
+            }
         }
 
         @Override
@@ -788,7 +820,7 @@ public final class ClientStreamFactory implements StreamFactory
                 // accept reply stream is allowed to outlive accept stream, so ignore END
                 break;
             case AbortFW.TYPE_ID:
-                detach();
+                detach(false);
                 break;
             default:
                 doReset(applicationThrottle, applicationId);

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcher.java
@@ -56,12 +56,13 @@ public class HeaderValueMessageDispatcher implements MessageDispatcher
     }
 
     @Override
-    public void detach()
+    public void detach(
+        boolean reattach)
     {
         for (int i = 0; i < dispatchers.size(); i++)
         {
             MessageDispatcher dispatcher = dispatchers.get(i);
-            dispatcher.detach();
+            dispatcher.detach(reattach);
         }
     }
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeadersMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeadersMessageDispatcher.java
@@ -56,13 +56,14 @@ public class HeadersMessageDispatcher implements MessageDispatcher
     }
 
     @Override
-    public void detach()
+    public void detach(
+        boolean reattach)
     {
-        broadcast.detach();
+        broadcast.detach(reattach);
         for (int i = 0; i < dispatchers.size(); i++)
         {
             MessageDispatcher dispatcher = dispatchers.get(i);
-            dispatcher.detach();
+            dispatcher.detach(reattach);
         }
     }
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KafkaError.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KafkaError.java
@@ -45,7 +45,7 @@ public enum KafkaError
     @Override
     public String toString()
     {
-        return format("%s (%d)", name(), errorCode);
+        return format("%d (%s)", errorCode, name());
     }
 
     public static KafkaError asKafkaError(short errorCode)

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcher.java
@@ -51,11 +51,12 @@ public class KeyMessageDispatcher implements MessageDispatcher
     }
 
     @Override
-    public void detach()
+    public void detach(
+        boolean reattach)
     {
         for (MessageDispatcher dispatcher: dispatchersByKey.values())
         {
-            dispatcher.detach();
+            dispatcher.detach(reattach);
         }
     }
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcher.java
@@ -43,7 +43,8 @@ public interface MessageDispatcher
 
     void adjustOffset(int partition, long oldOffset, long newOffset);
 
-    void detach();
+    void detach(
+        boolean reattach);
 
     int dispatch(
         int partition,

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcher.java
@@ -64,14 +64,15 @@ public class TopicMessageDispatcher implements MessageDispatcher, DecoderMessage
     }
 
     @Override
-    public void detach()
+    public void detach(
+        boolean reattach)
     {
-        broadcast.detach();
+        broadcast.detach(reattach);
         for (int i=0; i < keys.length; i++)
         {
-            keys[i].detach();
+            keys[i].detach(reattach);
         }
-        headers.detach();
+        headers.detach(reattach);
     }
 
     @Override

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BackoffTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BackoffTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.kafka.internal.stream;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public final class BackoffTest
+{
+
+    @Test
+    public void shouldStartWithMinumum()
+    {
+        Backoff backoff = new Backoff(500, 10_000);
+        assertEquals(500, backoff.next(0));
+    }
+    @Test
+    public void test()
+    {
+        Backoff backoff = new Backoff(1, 10_000);
+        assertEquals(10_000, backoff.next(30));
+        assertEquals(10_000, backoff.next(31));
+        assertEquals(10_000, backoff.next(32));
+        assertEquals(10_000, backoff.next(33));
+        assertEquals(10_000, backoff.next(40));
+    }
+
+    @Test
+    public void shouldDoubleUpToMaximum()
+    {
+        Backoff backoff = new Backoff(500, 10 * 1000);
+        int i = 0;
+        assertEquals(1000, backoff.next(++i));
+        assertEquals(2000, backoff.next(++i));
+        assertEquals(4000, backoff.next(++i));
+        assertEquals(8000, backoff.next(++i));
+        assertEquals(10000, backoff.next(++i));
+        assertEquals(10000, backoff.next(31));
+        assertEquals(10000, backoff.next(32));
+        assertEquals(10000, backoff.next(123456));
+    }
+
+    @Test
+    public void shouldHandleMaximumLessThanMinimum()
+    {
+        Backoff backoff = new Backoff(1000, 50);
+        assertEquals(50, backoff.next(0));
+        assertEquals(50, backoff.next(123));
+    }
+
+}

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BackoffTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BackoffTest.java
@@ -28,16 +28,6 @@ public final class BackoffTest
         Backoff backoff = new Backoff(500, 10_000);
         assertEquals(500, backoff.next(0));
     }
-    @Test
-    public void test()
-    {
-        Backoff backoff = new Backoff(1, 10_000);
-        assertEquals(10_000, backoff.next(30));
-        assertEquals(10_000, backoff.next(31));
-        assertEquals(10_000, backoff.next(32));
-        assertEquals(10_000, backoff.next(33));
-        assertEquals(10_000, backoff.next(40));
-    }
 
     @Test
     public void shouldDoubleUpToMaximum()
@@ -54,12 +44,22 @@ public final class BackoffTest
         assertEquals(10000, backoff.next(123456));
     }
 
-    @Test
-    public void shouldHandleMaximumLessThanMinimum()
+    @Test(expected = AssertionError.class)
+    public void shouldRejectMaximumLessThanMinimum()
     {
-        Backoff backoff = new Backoff(1000, 50);
-        assertEquals(50, backoff.next(0));
-        assertEquals(50, backoff.next(123));
+        new Backoff(1000, 50);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void shouldRejectNegativeMaximum()
+    {
+        new Backoff(-10, -50);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void shouldRejectNegativeMinium()
+    {
+        new Backoff(-10, 50);
     }
 
 }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BroadcastMessageDispatcherTest.java
@@ -78,11 +78,11 @@ public final class BroadcastMessageDispatcherTest
         context.checking(new Expectations()
         {
             {
-                oneOf(child1).detach();
-                oneOf(child2).detach();
+                oneOf(child1).detach(false);
+                oneOf(child2).detach(false);
             }
         });
-        dispatcher.detach();
+        dispatcher.detach(false);
     }
 
     @Test

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
@@ -116,22 +116,6 @@ public class CachingFetchIT
 
     @Test
     @Specification({
-        "${routeAnyTopic}/client/controller",
-        "${client}/zero.offset.two.topics/client",
-        "${metadata}/unknown.and.known.topics/server" })
-    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldRepeatMetadataRequestsWhenTopicIsUnknownWithoutBlockingOtherTopicUsage() throws Exception
-    {
-        k3po.start();
-        k3po.awaitBarrier("SECOND_UNKNOWN_TOPIC_METADATA_REQUEST_RECEIVED");
-        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
-        k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
-        k3po.notifyBarrier("WRITE_SECOND_UNKNOWN_TOPIC_METADATA_RESPONSE");
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
         "${route}/client/controller",
         "${client}/compacted.delivers.deleted.messages/client",
         "${server}/compacted.delivers.deleted.messages/server"})

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
@@ -263,8 +263,8 @@ public class CachingFetchIT
 //    @Test
 //    @Specification(
 //    {"${route}/client/controller",
-//            "${client}/compacted.historical.uses.cached.key.then.live.after.offset.too.early.and.null.message/client",
-//            "${server}/compacted.historical.uses.cached.key.then.live.after.offset.too.early.and.null.message/server"})
+//            "${client}/compacted.historical.uses.cached.key.then.live.after.offset.too.low.and.null.message/client",
+//            "${server}/compacted.historical.uses.cached.key.then.live.after.offset.too.low.and.null.message/server"})
 //    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
 //    public void shouldReceiveCompactedMessagesFromLiveStreamAfterOffsetTooEarlyAndCachedKeyRemovedByNullMessage()
 //            throws Exception
@@ -621,8 +621,8 @@ public class CachingFetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/fetch.key.nonzero.offset.too.early.message/client",
-        "${server}/fetch.key.nonzero.offset.too.early.first.matches/server"})
+        "${client}/fetch.key.nonzero.offset.too.low.message/client",
+        "${server}/fetch.key.nonzero.offset.too.low.first.matches/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldUseEarliestAvailableOffsetIfGreaterThanRequestedOffset() throws Exception
     {
@@ -786,8 +786,8 @@ public class CachingFetchIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/offset.too.early.message/client",
-        "${server}/offset.too.early.message/server" })
+        "${client}/offset.too.low.message/client",
+        "${server}/offset.too.low.message/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldRefetchUsingReportedFirstOffset() throws Exception
     {
@@ -799,8 +799,8 @@ public class CachingFetchIT
     @Test
     @Specification({
         "${routeAnyTopic}/client/controller",
-        "${client}/offset.too.early.multiple.nodes/client",
-        "${server}/offset.too.early.multiple.nodes/server" })
+        "${client}/offset.too.low.multiple.nodes/client",
+        "${server}/offset.too.low.multiple.nodes/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldRefetchUsingReportedFirstOffsetOnMultipleNodes() throws Exception
     {
@@ -810,8 +810,8 @@ public class CachingFetchIT
     @Test
     @Specification({
         "${routeAnyTopic}/client/controller",
-        "${client}/offset.too.early.multiple.topics/client",
-        "${server}/offset.too.early.multiple.topics/server" })
+        "${client}/offset.too.low.multiple.topics/client",
+        "${server}/offset.too.low.multiple.topics/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldRefetchUsingReportedFirstOffsetOnMultipleTopics() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
@@ -117,11 +117,16 @@ public class CachingFetchIT
     @Test
     @Specification({
         "${routeAnyTopic}/client/controller",
-        "${client}/unknown.topic.name/client",
-        "${metadata}/two.topics.error.unknown.topic/server" })
+        "${client}/zero.offset.two.topics/client",
+        "${metadata}/unknown.and.known.topics/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldRejectWhenTopicIsUnknown() throws Exception
+    public void shouldRepeatMetadataRequestsWhenTopicIsUnknownWithoutBlockingOtherTopicUsage() throws Exception
     {
+        k3po.start();
+        k3po.awaitBarrier("SECOND_UNKNOWN_TOPIC_METADATA_REQUEST_RECEIVED");
+        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
+        k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
+        k3po.notifyBarrier("WRITE_SECOND_UNKNOWN_TOPIC_METADATA_RESPONSE");
         k3po.finish();
     }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -1347,26 +1347,6 @@ public class FetchIT
         "${server}/live.fetch.error.recovered/server" })
     @ScriptProperty({
     "networkAccept \"nukleus://target/streams/kafka\"",
-    "errorCode 3s"
-    })
-    public void shouldContinueReceivingMessagesWhenTopicFetchResponseIsErrorCode3DuringKafkaRestart() throws Exception
-    {
-        k3po.start();
-        k3po.awaitBarrier("FIRST_FETCH_REQUEST_RECEIVED");
-        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
-        k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
-        awaitWindowFromClient();
-        k3po.notifyBarrier("WRITE_FIRST_FETCH_RESPONSE");
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${routeAnyTopic}/client/controller",
-        "${client}/zero.offset.message.two.topics/client",
-        "${server}/live.fetch.error.recovered/server" })
-    @ScriptProperty({
-    "networkAccept \"nukleus://target/streams/kafka\"",
     "errorCode 6s"
     })
     public void shouldContinueReceivingMessagesAfterLeadershipElection() throws Exception
@@ -1430,7 +1410,7 @@ public class FetchIT
     @Test
     @Specification({
         "${routeAnyTopic}/client/controller",
-        "${client}/zero.offset.message.end.with.offset.zero.message/client",
+        "${client}/zero.offset.message.reattach.message/client",
         "${server}/live.fetch.topic.not.found.recovered/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldEndWithOffsetZeroWhenTopicIsDeletedThenRecreated() throws Exception

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -345,7 +345,7 @@ public class FetchIT
         k3po.start();
         k3po.awaitBarrier("ROUTED_CLIENT");
         k3po.awaitBarrier("RECEIVED_NEXT_FETCH_REQUEST");
-        k3po.notifyBarrier("SUBSCRIBE_CLIENT");
+        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
         k3po.finish();
     }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -900,10 +900,8 @@ public class FetchIT
         "${client}/nonzero.offset.reattach.message/client",
         "${server}/offset.too.high.message/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldRefetchUsingLowerReportedFirstOffset() throws Exception
+    public void shouldReattachAndRefetchUsingLowerReportedFirstOffset() throws Exception
     {
-        k3po.start();
-        k3po.notifyBarrier("WRITE_FETCH_RESPONSE");
         k3po.finish();
     }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/HeaderValueMessageDispatcherTest.java
@@ -120,11 +120,11 @@ public final class HeaderValueMessageDispatcherTest
         context.checking(new Expectations()
         {
             {
-                oneOf(child1).detach();
-                oneOf(child2).detach();
+                oneOf(child1).detach(true);
+                oneOf(child2).detach(true);
             }
         });
-        dispatcher.detach();
+        dispatcher.detach(true);
     }
 
     @Test

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/KeyMessageDispatcherTest.java
@@ -88,11 +88,11 @@ public final class KeyMessageDispatcherTest
         context.checking(new Expectations()
         {
             {
-                oneOf(child1).detach();
-                oneOf(child2).detach();
+                oneOf(child1).detach(false);
+                oneOf(child2).detach(false);
             }
         });
-        dispatcher.detach();
+        dispatcher.detach(false);
     }
 
     @Test

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MetadataIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MetadataIT.java
@@ -260,4 +260,20 @@ public class MetadataIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${routeAnyTopic}/client/controller",
+        "${client}/zero.offset.two.topics/client",
+        "${metadata}/unknown.and.known.topics/server" })
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldRepeatMetadataRequestsWhenTopicIsUnknownWithoutBlockingOtherTopicUsage() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("SECOND_UNKNOWN_TOPIC_METADATA_REQUEST_RECEIVED");
+        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
+        k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
+        k3po.notifyBarrier("WRITE_SECOND_UNKNOWN_TOPIC_METADATA_RESPONSE");
+        k3po.finish();
+    }
 }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MetadataIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MetadataIT.java
@@ -28,6 +28,7 @@ import org.kaazing.k3po.junit.annotation.Specification;
 import org.kaazing.k3po.junit.rules.K3poRule;
 import org.reaktivity.nukleus.kafka.internal.KafkaConfiguration;
 import org.reaktivity.reaktor.test.ReaktorRule;
+import org.reaktivity.reaktor.test.annotation.Configure;
 
 public class MetadataIT
 {
@@ -262,18 +263,24 @@ public class MetadataIT
     }
 
     @Test
+    @Configure(name=KafkaConfiguration.READ_IDLE_TIMEOUT_PROPERTY, value="2000000")
     @Specification({
         "${routeAnyTopic}/client/controller",
-        "${client}/zero.offset.two.topics/client",
+        "${client}/zero.offset.multiple.topics/client",
         "${metadata}/unknown.and.known.topics/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldRepeatMetadataRequestsWhenTopicIsUnknownWithoutBlockingOtherTopicUsage() throws Exception
+    public void shouldRepeatMetadataRequestsWhileTopicIsUnknownAndClientsAreAttachedWithoutBlockingOtherTopicUsage()
+            throws Exception
     {
         k3po.start();
         k3po.awaitBarrier("SECOND_UNKNOWN_TOPIC_METADATA_REQUEST_RECEIVED");
         k3po.notifyBarrier("CONNECT_CLIENT_TWO");
         k3po.awaitBarrier("CLIENT_TWO_CONNECTED");
         k3po.notifyBarrier("WRITE_SECOND_UNKNOWN_TOPIC_METADATA_RESPONSE");
+        k3po.awaitBarrier("THIRD_UNKNOWN_TOPIC_METADATA_REQUEST_RECEIVED");
+        k3po.notifyBarrier("DISCONNECT_CLIENT_ONE");
+        k3po.notifyBarrier("WRITE_THIRD_UNKNOWN_TOPIC_METADATA_RESPONSE");
+        k3po.notifyBarrier("CONNECT_CLIENT_THREE");
         k3po.finish();
     }
 }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/TopicMessageDispatcherTest.java
@@ -111,11 +111,11 @@ public final class TopicMessageDispatcherTest
         context.checking(new Expectations()
         {
             {
-                oneOf(child1).detach();
-                oneOf(child2).detach();
+                oneOf(child1).detach(true);
+                oneOf(child2).detach(true);
             }
         });
-        dispatcher.detach();
+        dispatcher.detach(true);
     }
 
     @Test


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/66

- Clients are allowed to attach to topics which are not found (unknown). Message flow begins when the topic is created and messages are available.  
- If error code 3 is received in a fetch response, then the topic metadata is invalidated and repeated attempts are made to get it until successful. When successful (most likely meaning  the topic has been re-created) clients are detached and told to reattach at offset 0 by sending an END with offsets 0 in the END extension.
- Whenever a metadata get call results in error code 3 (topic not found), repeated attempts are made to get the topic metadata until successful (error code 0), with backoff (see new **Backoff** class).