### PR TITLE
leaveGroup is called after detaching the stream

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactoryBuilder.java
@@ -26,6 +26,7 @@ import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.Long2LongHashMap;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.reaktivity.nukleus.buffer.BufferPool;
 import org.reaktivity.nukleus.kafka.internal.KafkaConfiguration;
@@ -44,6 +45,8 @@ public final class ClientStreamFactoryBuilder implements StreamFactoryBuilder
     private final Long2ObjectHashMap<NetworkConnectionPool.AbstractNetworkConnection> correlations;
     private final Map<String, Long2ObjectHashMap<NetworkConnectionPool>> connectionPools;
     private final DelayedTaskScheduler scheduler;
+    private final Long2LongHashMap groupBudget;
+    private final Long2LongHashMap groupMembers;
 
     private RouteManager router;
     private MutableDirectBuffer writeBuffer;
@@ -68,6 +71,8 @@ public final class ClientStreamFactoryBuilder implements StreamFactoryBuilder
         this.correlations = new Long2ObjectHashMap<>();
         this.connectionPools = connectionPools;
         this.scheduler = scheduler;
+        this.groupBudget = new Long2LongHashMap(-1);
+        this.groupMembers = new Long2LongHashMap(-1);
     }
 
     @Override
@@ -161,6 +166,6 @@ public final class ClientStreamFactoryBuilder implements StreamFactoryBuilder
 
         return new ClientStreamFactory(config, router, writeBuffer, bufferPool, memoryManager, supplyStreamId, supplyTrace,
                 supplyCorrelationId, supplyCounter, correlations, connectionPools, connectPoolFactoryConsumer, scheduler,
-                counters);
+                counters, groupBudget, groupMembers);
     }
 }


### PR DESCRIPTION
* groupBudget map is moved to builder so that all the factories share them

* leaveGroup() should be called after detach the stream. Otherwise, that stream
may flush more messages