### PR TITLE
Added test case for partially delivered message is no longer available.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkout coalesced_messages
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
-  - cd nukleus-kafka.spec
-  - git checkout coalesced_messages
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.83</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.84</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -662,13 +662,13 @@ public final class ClientStreamFactory implements StreamFactory
                    dispatchBlocked = true;
                    skipMessage = true;
                }
-               else if (messageStartOffset < fragmentedMessageOffset)
-               {
-                   skipMessage = true;
-               }
-               else if (messageStartOffset == fragmentedMessageOffset)
+               else if  (messageStartOffset == fragmentedMessageOffset)
                {
                    fragmentedMessageDispatched = true;
+               }
+               else
+               {
+                   skipMessage = true;
                }
             }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapCachingIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapCachingIT.java
@@ -89,7 +89,7 @@ public class BootstrapCachingIT
     @Specification({
         "${route}/client/controller",
         "${client}/compacted.historical.large.message.and.small/client",
-        "${server}/compacted.messages.first.exceeds.256.bytes/server"})
+        "${server}/compacted.messages.large.and.small/server"})
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
         "applicationConnectWindow1 \"2000\"",

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/BootstrapIT.java
@@ -73,6 +73,16 @@ public class BootstrapIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${server}/compacted.offset.too.low.message/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldBootstrapTopicStartingWithOffsetTooLow() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${server}/compacted.messages.multiple.nodes/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldBootstrapTopicWithMultiplePartitionsOnMultipleNodes() throws Exception

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchLimitsIT.java
@@ -59,7 +59,7 @@ public class CachingFetchLimitsIT
     @Specification({
         "${route}/client/controller",
         "${client}/compacted.historical.large.message.subscribed.to.key/client",
-        "${server}/compacted.messages.first.exceeds.256.bytes.repeated/server"})
+        "${server}/compacted.messages.large.and.small.repeated/server"})
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
         "applicationConnectWindow \"200\""

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -64,7 +64,7 @@ public class FetchLimitsIT
     @Specification({
         "${route}/client/controller",
         "${client}/compacted.large.message.subscribed.to.key/client",
-        "${server}/compacted.messages.first.exceeds.256.bytes/server"})
+        "${server}/compacted.messages.large.and.small/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveLargeCompactedMessageWhenSubscribedToKey() throws Exception
     {
@@ -75,7 +75,7 @@ public class FetchLimitsIT
     @Specification({
         "${route}/client/controller",
         "${client}/compacted.large.message.subscribed.to.key/client",
-        "${server}/compacted.messages.first.exceeds.256.bytes.repeated/server"})
+        "${server}/compacted.messages.large.and.small.repeated/server"})
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
         "applicationConnectWindow \"200\""
@@ -88,8 +88,19 @@ public class FetchLimitsIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/zero.offset.partial.message.aborted/client",
+        "${server}/zero.offset.messages.large.and.small.then.large.missing/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldBeDettachedWhenPartiallyDeliveredMessageNoLongerAvailable() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/zero.offset.large.message/client",
-        "${server}/zero.offset.messages.first.exceeds.256.bytes/server"})
+        "${server}/zero.offset.messages.large.and.small/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveMessageExceedingBufferSlotCapacity() throws Exception
     {
@@ -100,7 +111,7 @@ public class FetchLimitsIT
     @Specification({
         "${route}/client/controller",
         "${client}/zero.offset.large.message/client",
-        "${server}/zero.offset.messages.first.exceeds.256.bytes.repeated/server"})
+        "${server}/zero.offset.messages.large.and.small.repeated/server"})
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
         "applicationConnectWindow \"200\""


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/69

Fixed handling of this condition so we no longer attempt to send the following message as continuation of the partially delivered one.
Renamed scripts ...message.first.exceeds.256.bytes... to ...messsages.large.and.small....
Added test case for bootstrap with offset too low (compacted.offset.too.low.message).