### PR TITLE
Fixing test by ordering RESET and metadata response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.86</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -1076,8 +1076,10 @@ public class FetchIT
     public void shouldHandleResetFromClientWithoutCausingNPEInDoFetchRequest() throws Exception
     {
         k3po.start();
-        k3po.awaitBarrier("DESCRIBE_CONFIGS_REQUEST_RECEIVED");
+        k3po.awaitBarrier("KNOWN_TOPIC_METADATA_REQUEST_RECEIVED");
         k3po.notifyBarrier("DO_RESET");
+        k3po.awaitBarrier("CONNECT_CLIENT_TWO");
+        k3po.notifyBarrier("SEND_METADATA_RESPONSE");
         k3po.finish();
     }
 


### PR DESCRIPTION
Fixing RESET from client and WINDOW from broker race (If RESET comes
first, "test1" is cleared from topicsName, and fetch request contains
only "test2". If WINDOW comes first, "test1" will be there in fetch
request).

Now barriers are introduced to delay metadata response and
will be notified only when the first client is RESET