### PR TITLE
Added test case for receiving empty message from cache 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkout empty_message
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
-  - cd nukleus-kafka.spec
-  - git checkout empty_message
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.88</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.87</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchIT.java
@@ -156,6 +156,17 @@ public class CachingFetchIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/compacted.historical.empty.message/client",
+        "${server}/compacted.empty.message/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldReceiveCompactedEmptyMessageFromCacheWhenSubscribedToKey() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/compacted.header.message.multiple.clients/client",
         "${server}/compacted.header.first.matches.repeated/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/73

Added test case for receiving empty message from cache (reproducing the now fixed IllegalStateException caused by attempting to wrap an UnsafeBuffer in another with offset = wrappee.capacity)