### PR TITLE
Added counter for internal.errors and handling for case where an incorrect value is dispatched

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
-  - cd nukleus-kafka.spec
-  - git checkout index_out_of_bounds
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - rm ~/.m2/settings.xml
   - git clone https://github.com/cmebarrow/nukleus-kafka.spec
   - cd nukleus-kafka.spec
-  - git checkoutindex_out_of_bounds
+  - git checkout index_out_of_bounds
   - mvn clean install -DskipTests
   - cd ..
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkoutindex_out_of_bounds
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.89</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.87</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaRefCounters.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaRefCounters.java
@@ -27,6 +27,8 @@ public class KafkaRefCounters
     public final LongSupplier describeConfigsRequestIdleTimeouts;
     public final LongSupplier listOffsetsRequestIdleTimeouts;
     public final LongSupplier fetchRequestIdleTimeouts;
+    public final LongSupplier forcedDetaches;
+    public final LongSupplier internalErrors;
 
     KafkaRefCounters(
         String networkName,
@@ -42,5 +44,9 @@ public class KafkaRefCounters
                 format("list.offsets.request.idle.timeouts.%s.%d", networkName, networkRef));
         this.fetchRequestIdleTimeouts = supplyCounter.apply(
                 format("fetch.request.idle.timeouts.%s.%d", networkName, networkRef));
+        this.forcedDetaches = supplyCounter.apply(
+                format("forced.detaches.%s.%d", networkName, networkRef));
+        this.internalErrors = supplyCounter.apply(
+                format("internal.errors.%s.%d", networkName, networkRef));
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -550,6 +550,11 @@ public final class NetworkConnectionPool
         }
     }
 
+    KafkaRefCounters getRouteCounters()
+    {
+        return routeCounters;
+    }
+
     void removeConnection(LiveFetchConnection connection)
     {
         connections = ArrayUtil.remove(connections, connection);

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchLimitsIT.java
@@ -71,6 +71,20 @@ public class CachingFetchLimitsIT
 
     @Test
     @Specification({
+        "${route}/client/controller",
+        "${client}/compacted.historical.large.message.subscribed.to.key/client",
+        "${server}/compacted.messages.large.and.small.repeated/server"})
+    @ScriptProperty({
+        "networkAccept \"nukleus://target/streams/kafka\"",
+        "applicationConnectWindow \"200\""
+    })
+    public void shouldReceiveCompactedFragmentedMessageThenSmallMessageFromCacheWhenSubscribedToKey() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${control}/route.ext.header/client/controller",
         "${client}/compacted.messages.header.multiple.clients/client",
         "${server}/compacted.messages.header/server"})

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -91,7 +91,7 @@ public class FetchLimitsIT
         "${client}/zero.offset.partial.message.aborted/client",
         "${server}/zero.offset.messages.large.and.small.then.large.missing/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    public void shouldBeDettachedWhenPartiallyDeliveredMessageNoLongerAvailable() throws Exception
+    public void shouldBeDetachedWhenPartiallyDeliveredMessageNoLongerAvailable() throws Exception
     {
         k3po.finish();
     }


### PR DESCRIPTION
...for a partially delivered message.
Added counter for forced.detaches (when a partially delivered message is no longer available).
Added more tests for partially delivered messages.

Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/74