### PR TITLE
java.lang.OutOfMemoryError: Direct buffer memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkout broker_config_change
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
-  - cd nukleus-kafka.spec
-  - git checkout broker_config_change
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.86</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.90</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -617,7 +617,7 @@ public final class NetworkConnectionPool
         @Override
         public String toString()
         {
-            return format("%s [budget=%d, padding=%d, networkId=%d, networkReplyId=%d, nextRequestId %d, nextResponseId %d]",
+            return format("%s [budget=%d, padding=%d, networkId=%x, networkReplyId=%x, nextRequestId %d, nextResponseId %d]",
                     getClass().getSimpleName(), networkRequestBudget, networkRequestPadding,
                     networkId, networkReplyId, nextRequestId, nextResponseId);
         }
@@ -798,7 +798,7 @@ public final class NetworkConnectionPool
             if (frame.streamId() != networkReplyId)
             {
                 // reject deferred DATA / END / ABORT after idle ABORT without RESET
-                clientStreamFactory.doReset(networkReplyThrottle, networkReplyId);
+                clientStreamFactory.doReset(networkReplyThrottle, frame.streamId());
                 return;
             }
 
@@ -1006,6 +1006,7 @@ public final class NetworkConnectionPool
             networkReplyId = 0L;
             nextRequestId = 0;
             nextResponseId = 0;
+            streamState = this::beforeBegin;
         }
     }
 
@@ -1427,7 +1428,7 @@ public final class NetworkConnectionPool
         }
 
         @Override
-        void handleConnectionFailed()
+        final void handleConnectionFailed()
         {
             invalidateConnectionMetadata();
             doReinitialize();
@@ -1516,7 +1517,7 @@ public final class NetworkConnectionPool
         @Override
         public String toString()
         {
-            return format("%s [broker=%s, budget=%d, padding=%d, networkId=%d, networkReplyId=%d," +
+            return format("%s [broker=%s, budget=%d, padding=%d, networkId=%x, networkReplyId=%x," +
                           "nextRequestId=%d, nextResponseId=%d]",
                     getClass().getSimpleName(), broker, networkRequestBudget, networkRequestPadding,
                     networkId, networkReplyId, nextRequestId, nextResponseId);

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -48,6 +48,7 @@ import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
 import java.util.function.IntToLongFunction;
 import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -478,28 +479,43 @@ public final class NetworkConnectionPool
     private <T extends AbstractFetchConnection> T[] applyBrokerMetadata(
         T[] connections,
         BrokerMetadata broker,
-        Function<BrokerMetadata, T> createConnection)
+        Supplier<T> createConnection)
     {
         T[] result = connections;
-        AbstractFetchConnection current = null;
+        T current = null;
+        T available = null;
         for (int i = 0; i < connections.length; i++)
         {
-            AbstractFetchConnection connection = connections[i];
-            if (connection.brokerId == broker.nodeId)
+            T connection = connections[i];
+            if (connection.broker == null)
+            {
+                available = connection;
+            }
+            else if (connection.broker.nodeId == broker.nodeId)
             {
                 current = connection;
-                if (!connection.host.equals(broker.host) || connection.port != broker.port)
+                if (!connection.broker.equals(broker))
                 {
-                    // Change in cluster configuration
-                    connection.close();
-                    current = createConnection.apply(broker);
+                    // Cluster node has moved to a new host or port
+                    current.close();
+                    current.doReinitialize();
+                    current.setBroker(broker);
                 }
                 break;
             }
         }
         if (current == null)
         {
-            result = ArrayUtil.add(connections, createConnection.apply(broker));
+            if (available != null)
+            {
+                current = available;
+            }
+            else
+            {
+                current = createConnection.get();
+                result = ArrayUtil.add(connections, current);
+            }
+            current.setBroker(broker);
         }
         return result;
     }
@@ -984,9 +1000,7 @@ public final class NetworkConnectionPool
         private static final long EARLIEST_AVAILABLE_OFFSET = -2L;
         private static final long NEXT_OFFSET = -1L; // high water mark (offset of the next published message)
 
-        final String host;
-        final int port;
-        final int brokerId;
+        BrokerMetadata broker;
 
         int encodeLimit;
         boolean offsetsNeeded;
@@ -997,13 +1011,9 @@ public final class NetworkConnectionPool
         private final LongSupplier fetches;
 
         private AbstractFetchConnection(
-            BrokerMetadata broker,
             LongSupplier fetches)
         {
             super();
-            this.brokerId = broker.nodeId;
-            this.host = broker.host;
-            this.port = broker.port;
             this.fetches = fetches;
             fetchResponseDecoder = new FetchResponseDecoder(
                     this::getTopicDispatcher,
@@ -1015,15 +1025,15 @@ public final class NetworkConnectionPool
         @Override
         void doRequestIfNeeded()
         {
-            if (nextRequestId == nextResponseId)
+            if (nextRequestId == nextResponseId && broker != null)
             {
                 doBeginIfNotConnected((b, o, m) ->
                 {
                     return tcpBeginExRW.wrap(b, o, m)
                             .localAddress(lab -> lab.ipv4Address(ob -> ob.put(ANY_IP_ADDR)))
                                       .localPort(0)
-                                      .remoteAddress(rab -> rab.host(host))
-                                      .remotePort(port)
+                                      .remoteAddress(rab -> rab.host(broker.host))
+                                      .remotePort(broker.port)
                                       .limit();
                 });
 
@@ -1177,7 +1187,7 @@ public final class NetworkConnectionPool
 
             for (TopicMetadata topicMetadata : topicMetadataByName.values())
             {
-                int partitionCount = topicMetadata.offsetsRequired(brokerId);
+                int partitionCount = topicMetadata.offsetsRequired(broker.nodeId);
                 if (partitionCount > 0)
                 {
                     topicCount++;
@@ -1192,7 +1202,7 @@ public final class NetworkConnectionPool
 
                     for (int partitionId=0; partitionId <  topicMetadata.nodeIdsByPartition.length; partitionId++)
                     {
-                        if (topicMetadata.nodeIdsByPartition[partitionId] == brokerId &&
+                        if (topicMetadata.nodeIdsByPartition[partitionId] == broker.nodeId &&
                             topicMetadata.offsetsOutOfRangeByPartition[partitionId] != NO_OFFSET)
                         {
                             long requestedTimestamp = topicMetadata.offsetsOutOfRangeByPartition[partitionId] == MAX_OFFSET
@@ -1406,22 +1416,27 @@ public final class NetworkConnectionPool
         void handleConnectionFailed()
         {
             invalidateConnectionMetadata();
-            removeConnection();
+            doReinitialize();
             metadataConnection.doRequestIfNeeded();
         }
 
-        abstract void removeConnection();
+        void setBroker(
+            BrokerMetadata broker)
+        {
+            this.broker = broker;
+        }
 
         private void invalidateConnectionMetadata()
         {
             for (TopicMetadata metadata : topicMetadataByName.values())
             {
-                if (metadata.invalidateBroker(brokerId))
+                if (metadata.invalidateBroker(broker.nodeId))
                 {
                     int newAttachId = nextAttachId++;
                     metadata.doAttach(newAttachId, this::metadataUpdated);
                 }
             }
+            broker = null;
         }
 
         private void metadataUpdated(TopicMetadata metadata)
@@ -1487,18 +1502,18 @@ public final class NetworkConnectionPool
         @Override
         public String toString()
         {
-            return format("%s [brokerId=%d, host=%s, port=%d, budget=%d, padding=%d, networkId=%d, networkReplyId=%d," +
+            return format("%s [broker=%s, budget=%d, padding=%d, networkId=%d, networkReplyId=%d," +
                           "nextRequestId=%d, nextResponseId=%d]",
-                    getClass().getSimpleName(), brokerId, host, port, networkRequestBudget, networkRequestPadding,
+                    getClass().getSimpleName(), broker, networkRequestBudget, networkRequestPadding,
                     networkId, networkReplyId, nextRequestId, nextResponseId);
         }
     }
 
     private final class LiveFetchConnection extends AbstractFetchConnection
     {
-        LiveFetchConnection(BrokerMetadata broker)
+        LiveFetchConnection()
         {
-            super(broker, NO_COUNTER);
+            super(NO_COUNTER);
         }
 
         @Override
@@ -1527,7 +1542,7 @@ public final class NetworkConnectionPool
                     next = iterator.hasNext() ? iterator.next() : null;
                     boolean isHighestOffset = next == null || next.id != candidate.id;
 
-                    if (isHighestOffset && nodeIdsByPartition[candidate.id] == brokerId)
+                    if (isHighestOffset && nodeIdsByPartition[candidate.id] == broker.nodeId)
                     {
                         if (candidate.offset == MAX_OFFSET)
                         {
@@ -1585,19 +1600,13 @@ public final class NetworkConnectionPool
 
             return partitionCount;
         }
-
-        @Override
-        void removeConnection()
-        {
-            NetworkConnectionPool.this.removeConnection(this);
-        }
     }
 
     private final class HistoricalFetchConnection extends AbstractFetchConnection
     {
-        private HistoricalFetchConnection(BrokerMetadata broker)
+        private HistoricalFetchConnection()
         {
-            super(broker, routeCounters.historicalFetches);
+            super(routeCounters.historicalFetches);
         }
 
         @Override
@@ -1629,7 +1638,7 @@ public final class NetworkConnectionPool
                         NetworkTopicPartition partition = partitions.next();
 
                         if (topic.needsHistorical(partition.id) &&
-                                partitionId < partition.id && nodeIdsByPartition[partition.id] == brokerId)
+                                partitionId < partition.id && nodeIdsByPartition[partition.id] == broker.nodeId)
                         {
                             long offset = metadata.ensureOffsetInRange(partition.id, partition.offset);
                             PartitionRequestFW partitionRequest = NetworkConnectionPool.this.partitionRequestRW
@@ -1675,12 +1684,6 @@ public final class NetworkConnectionPool
             }
 
             return partitionCount;
-        }
-
-        @Override
-        void removeConnection()
-        {
-            NetworkConnectionPool.this.removeConnection(this);
         }
     }
 
@@ -2732,6 +2735,33 @@ public final class NetworkConnectionPool
             this.nodeId = nodeId;
             this.host = host;
             this.port = port;
+        }
+
+        @Override
+        public boolean equals(
+            Object obj)
+        {
+            BrokerMetadata that;
+            return (this == obj ||
+                    (this != null &&
+                    obj instanceof BrokerMetadata &&
+                    this.nodeId == (that = (BrokerMetadata) obj).nodeId &&
+                    this.nodeId == that.nodeId &&
+                    this.host.equals(that.host) &&
+                    this.port == that.port)
+                    );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return super.hashCode();
+        }
+
+        @Override
+        public String toString()
+        {
+            return format("(nodeId=%d, host=%s, port=%d)", nodeId, host, port);
         }
     }
 

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -1413,7 +1413,7 @@ public class FetchIT
         "${server}/live.fetch.connection.reset/server" })
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     @Configure(name=KafkaConfiguration.READ_IDLE_TIMEOUT_PROPERTY, value="200000")
-    public void shouldAttachNewSubscribersWhenOneBrokerConnectionHasFailed()
+    public void shouldRefreshAllConnectionsToABrokerWhichFails()
             throws Exception
     {
         k3po.start();
@@ -1421,6 +1421,7 @@ public class FetchIT
         k3po.awaitBarrier("FIRST_FETCH_REQUEST_RECEIVED");
         k3po.awaitBarrier("READY_TO_FAIL_FETCH_CONNECTION_TWO");
         k3po.notifyBarrier("CONNECT_CLIENT_TWO");
+        k3po.awaitBarrier("HISTORICAL_TWO_FETCH_REQUEST_RECEIVED");
         k3po.notifyBarrier("FAIL_FETCH_CONNECTION_TWO");
         k3po.awaitBarrier("METADATA_REFRESH_REQUEST_RECEIVED");
         awaitWindowFromClient();

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchIT.java
@@ -1412,24 +1412,24 @@ public class FetchIT
     @Specification({
         "${routeAnyTopic}/client/controller",
         "${client}/zero.offset.message.multiple.partitions/client",
-        "${server}/live.fetch.connection.reset/server" })
+        "${server}/live.fetch.connection.reset/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
-    @Configure(name=KafkaConfiguration.READ_IDLE_TIMEOUT_PROPERTY, value="200000")
     public void shouldRefreshAllConnectionsToABrokerWhichFails()
             throws Exception
     {
         k3po.start();
         k3po.awaitBarrier("CLIENT_ONE_CONNECTED");
-        k3po.awaitBarrier("FIRST_FETCH_REQUEST_RECEIVED");
-        k3po.awaitBarrier("READY_TO_FAIL_FETCH_CONNECTION_TWO");
+        k3po.awaitBarrier("LIVE_ONE_FETCH_REQUEST_RECEIVED");
+        k3po.awaitBarrier("READY_TO_FAIL_LIVE_TWO");
         k3po.notifyBarrier("CONNECT_CLIENT_TWO");
         k3po.awaitBarrier("HISTORICAL_TWO_FETCH_REQUEST_RECEIVED");
-        k3po.notifyBarrier("FAIL_FETCH_CONNECTION_TWO");
+        k3po.notifyBarrier("FAIL_LIVE_TWO");
         k3po.awaitBarrier("METADATA_REFRESH_REQUEST_RECEIVED");
-        awaitWindowFromClient();
         k3po.notifyBarrier("WRITE_METADATA_REFRESH_RESPONSE");
-        k3po.awaitBarrier("FETCH_REQUEST_ON_RECONNECTED_CONNECTION_RECEIVED");
-        k3po.notifyBarrier("WRITE_FIRST_FETCH_RESPONSE");
+        k3po.awaitBarrier("RECONNECTED_LIVE_TWO_FETCH_REQUEST_RECEIVED");
+        k3po.notifyBarrier("WRITE_LIVE_ONE_FETCH_RESPONSE");
+        k3po.awaitBarrier("RECONNECTED_HISTORICAL_TWO_FETCH_REQUEST_RECEIVED");
+        k3po.notifyBarrier("WRITE_RECONNECTED_HISTORICAL_TWO_FETCH_RESPONSE");
         k3po.finish();
     }
 


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/76

Fixed handling of broker connection failures to avoid creating new  fetch connection objects and thence new decoding buffers (direct buffers).

Also fixed rejecting deferred DATA / END / ABORT to reset the correct stream.