### PR TITLE
Test case for clients being detached unnecessarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkout excessive_detach
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
-  - cd nukleus-kafka.spec
-  - git checkout excessive_detach
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.95</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.84</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/FetchLimitsIT.java
@@ -99,7 +99,25 @@ public class FetchLimitsIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/zero.offset.large.message/client",
+        "${client}/zero.offset.messages.large.and.small.fanout/client",
+        "${server}/zero.offset.messages.large.and.small.historical/server"})
+    @ScriptProperty({
+        "networkAccept \"nukleus://target/streams/kafka\"",
+        "applicationConnectWindow \"200\""
+    })
+    public void shouldNotDettachWhenDispatchingLiveMessageWhenHistoricalMessageIsPartiallyWritten()
+            throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("LIVE_FETCH_REQUEST_ONE_RECEIVED");
+        k3po.notifyBarrier("CONNECT_CLIENT_TWO");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
+        "${client}/zero.offset.messages.large.and.small/client",
         "${server}/zero.offset.messages.large.and.small/server"})
     @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
     public void shouldReceiveMessageExceedingBufferSlotCapacity() throws Exception
@@ -110,7 +128,7 @@ public class FetchLimitsIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/zero.offset.large.message/client",
+        "${client}/zero.offset.messages.large.and.small/client",
         "${server}/zero.offset.messages.large.and.small.repeated/server"})
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
@@ -124,7 +142,7 @@ public class FetchLimitsIT
     @Test
     @Specification({
         "${route}/client/controller",
-        "${client}/zero.offset.large.message/client",
+        "${client}/zero.offset.messages.large.and.small/client",
         "${server}/zero.offset.first.record.batch.large.requires.3.fetches/server"})
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",


### PR DESCRIPTION
The code changes in https://github.com/reaktivity/nukleus-kafka.java/pull/129 fixed an issue whereby clients were being detached unnecessarily. The fix was to add the condition  
`requestOffset <= fragmentedMessageOffset &&`  to the if statement in ClientAcceptStream.flush.

This PR adds a test case verifying this fix by checking that a client is not detached when a historical message has been partially delivered then a live message (at a higher offset) is processed.  The test fails if the above fix is commented out, proving that it is correct.

Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/79