### PR TITLE
Reduce CPU usage during replay of historical messages from cache

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaCounters.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/KafkaCounters.java
@@ -34,6 +34,8 @@ public class KafkaCounters
     public final LongConsumer cacheInUse;
     public final LongSupplier cacheBufferAcquires;
     public final LongSupplier cacheBufferReleases;
+    public final LongSupplier dispatchNoWindow;
+    public final LongSupplier dispatchNeedOtherMessage;
 
 
     public KafkaCounters(
@@ -46,6 +48,8 @@ public class KafkaCounters
         this.cacheHits = supplyCounter.apply("cache.hits");
         this.cacheMisses = supplyCounter.apply("cache.misses");
         this.cacheInUse = supplyAccumulator.apply("cache.inuse");
+        this.dispatchNoWindow = supplyCounter.apply("dispatch.no.window");
+        this.dispatchNeedOtherMessage = supplyCounter.apply("dispatch.need.other.message");
         this.cacheBufferAcquires = supplyCounter.apply("message.cache.buffer.acquires");
         this.cacheBufferReleases = supplyCounter.apply("message.cache.buffer.releases");
     }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -667,6 +667,7 @@ public final class ClientStreamFactory implements StreamFactory
                {
                    dispatchBlocked = true;
                    skipMessage = true;
+                   counters.dispatchNeedOtherMessage.getAsLong();
                }
                else if (messageStartOffset == fragmentedMessageOffset)
                {
@@ -693,6 +694,7 @@ public final class ClientStreamFactory implements StreamFactory
                else
                {
                    skipMessage = true;
+                   counters.dispatchNeedOtherMessage.getAsLong();
                }
             }
 
@@ -734,6 +736,7 @@ public final class ClientStreamFactory implements StreamFactory
                 else
                 {
                     dispatchBlocked = true;
+                    counters.dispatchNoWindow.getAsLong();
                 }
             }
             return result;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -2446,11 +2446,15 @@ public final class NetworkConnectionPool
             else
             {
                 writableBytes = Integer.MAX_VALUE;
+
                 // TODO: eliminate iterator allocation
                 for (IntSupplier supplyWindow : windowSuppliers)
                 {
-                    writableBytes = Math.min(writableBytes, supplyWindow.getAsInt());
+                   // Get lowest non-zero value
+                   int lowest = Math.min(writableBytes, supplyWindow.getAsInt());
+                   writableBytes = lowest == 0 ? writableBytes : lowest;
                 }
+
                 writableBytes = writableBytes == Integer.MAX_VALUE ? 0 : writableBytes;
             }
             return writableBytes;

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -1557,7 +1557,7 @@ public final class NetworkConnectionPool
             IntToLongFunction getRequestedOffset)
         {
             final NetworkTopic topic = topicsByName.get(topicName);
-            final int maxPartitionBytes = topic.maximumWritableBytes(true);
+            final int maxPartitionBytes = topic.writableBytes(true);
             final TopicMetadata metadata = topicMetadataByName.get(topicName);
 
             int partitionCount = 0;
@@ -1655,7 +1655,7 @@ public final class NetworkConnectionPool
             NetworkTopic topic = topicsByName.get(topicName);
             if (topic.needsHistorical())
             {
-                final int maxPartitionBytes = topic.maximumWritableBytes(false);
+                final int maxPartitionBytes = topic.writableBytes(false);
                 final TopicMetadata metadata = topicMetadataByName.get(topicName);
 
                 if (maxPartitionBytes > 0 && metadata != null)
@@ -2436,20 +2436,22 @@ public final class NetworkConnectionPool
             }
         }
 
-        int maximumWritableBytes(boolean live)
+        int writableBytes(boolean live)
         {
-            int writableBytes = 0;
+            int writableBytes;
             if (live && proactive)
             {
                 writableBytes = fetchPartitionMaxBytes;
             }
             else
             {
+                writableBytes = Integer.MAX_VALUE;
                 // TODO: eliminate iterator allocation
                 for (IntSupplier supplyWindow : windowSuppliers)
                 {
-                    writableBytes = Math.max(writableBytes, supplyWindow.getAsInt());
+                    writableBytes = Math.min(writableBytes, supplyWindow.getAsInt());
                 }
+                writableBytes = writableBytes == Integer.MAX_VALUE ? 0 : writableBytes;
             }
             return writableBytes;
         }


### PR DESCRIPTION
Changed the logic for calculating how many bytes to attempt to fetch per topic partition on historical fetch streams, in method network topic.writableBytes (renamed from topic.maximumWritableBytes), to return the minimum nonzero window instead of the maximum available window.

Also added counters as follows to help monitor dispatching efficiency:

- dispatch.no.window:  number of times ClientAcceptStream attempted to deliver a message but could not because there was no window
- dispatch.need.other.message:  number of times a message could not be delivered because another message had already been partially delivered