### PR TITLE
Avoided stopping dispatching from cache prematurely to avoid stuck flow

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -727,10 +727,6 @@ public final class ClientStreamFactory implements StreamFactory
                     if (bytesToWrite < payloadLength)
                     {
                         dispatchBlocked = true;
-                        if (bytesToWrite > 0)
-                        {
-                            result |= MessageDispatcher.FLAGS_WRITTEN;
-                        }
                     }
                     else
                     {
@@ -742,6 +738,7 @@ public final class ClientStreamFactory implements StreamFactory
                     dispatchBlocked = true;
                     counters.dispatchNoWindow.getAsLong();
                 }
+                result |= MessageDispatcher.FLAGS_EXPECTING_WINDOW;
             }
             return result;
         }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/ClientStreamFactory.java
@@ -727,6 +727,10 @@ public final class ClientStreamFactory implements StreamFactory
                     if (bytesToWrite < payloadLength)
                     {
                         dispatchBlocked = true;
+                        if (bytesToWrite > 0)
+                        {
+                            result |= MessageDispatcher.FLAGS_WRITTEN;
+                        }
                     }
                     else
                     {

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcher.java
@@ -23,17 +23,17 @@ import org.agrona.DirectBuffer;
 public interface MessageDispatcher
 {
     int FLAGS_MATCHED = 0x01;
-    int FLAGS_WRITTEN = 0x02 | FLAGS_MATCHED;
-    int FLAGS_DELIVERED = 0x04 | FLAGS_WRITTEN;
+    int FLAGS_EXPECTING_WINDOW = 0x02 | FLAGS_MATCHED;
+    int FLAGS_DELIVERED = 0x04 | FLAGS_EXPECTING_WINDOW;
 
     static boolean matched(int result)
     {
         return (result & FLAGS_MATCHED) == FLAGS_MATCHED;
     }
 
-    static boolean written(int result)
+    static boolean expectingWindow(int result)
     {
-        return (result & FLAGS_WRITTEN) == FLAGS_WRITTEN;
+        return (result & FLAGS_EXPECTING_WINDOW) == FLAGS_EXPECTING_WINDOW;
     }
 
     static boolean delivered(int result)

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcher.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcher.java
@@ -23,11 +23,17 @@ import org.agrona.DirectBuffer;
 public interface MessageDispatcher
 {
     int FLAGS_MATCHED = 0x01;
-    int FLAGS_DELIVERED = 0x02 | FLAGS_MATCHED;
+    int FLAGS_WRITTEN = 0x02 | FLAGS_MATCHED;
+    int FLAGS_DELIVERED = 0x04 | FLAGS_WRITTEN;
 
     static boolean matched(int result)
     {
         return (result & FLAGS_MATCHED) == FLAGS_MATCHED;
+    }
+
+    static boolean written(int result)
+    {
+        return (result & FLAGS_WRITTEN) == FLAGS_WRITTEN;
     }
 
     static boolean delivered(int result)

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -2504,10 +2504,10 @@ public final class NetworkConnectionPool
                                 message.headers().limit());
 
                         // call the dispatch variant which does not attempt to re-cache the message
-                        dispatcher.dispatch(partitionId, requestOffset, newOffset, key, headers.headerSupplier(),
+                        int result = dispatcher.dispatch(partitionId, requestOffset, newOffset, key, headers.headerSupplier(),
                                 message.timestamp(), message.traceId(), value);
 
-                        if (value != null)
+                        if (value != null && MessageDispatcher.written(result))
                         {
                             dispatchedBytes += value.capacity();
                         }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/NetworkConnectionPool.java
@@ -2480,6 +2480,7 @@ public final class NetworkConnectionPool
                 long logStartOffset = request.logStartOffset();
                 int maxBytes = request.maxBytes();
                 int dispatchedBytes = 0;
+                boolean expectingWindow = false;
                 long newOffset = fetchOffset;
                 Iterator<Entry> entries = dispatcher.entries(partitionId, fetchOffset);
                 boolean partitionRequestNeeded = false;
@@ -2507,7 +2508,12 @@ public final class NetworkConnectionPool
                         int result = dispatcher.dispatch(partitionId, requestOffset, newOffset, key, headers.headerSupplier(),
                                 message.timestamp(), message.traceId(), value);
 
-                        if (value != null && MessageDispatcher.written(result))
+                        if (MessageDispatcher.expectingWindow(result))
+                        {
+                            expectingWindow = true;
+                        }
+
+                        if (value != null && expectingWindow)
                         {
                             dispatchedBytes += value.capacity();
                         }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcherTest.java
@@ -25,13 +25,13 @@ public final class MessageDispatcherTest
     @Test
     public void shouldDetectFlagsDelivered()
     {
-        assertFalse(MessageDispatcher.written(0x01));
+        assertFalse(MessageDispatcher.expectingWindow(0x01));
         assertFalse(MessageDispatcher.delivered(0x01));
-        assertFalse(MessageDispatcher.written(0x02));
+        assertFalse(MessageDispatcher.expectingWindow(0x02));
         assertFalse(MessageDispatcher.delivered(0x02));
         assertFalse(MessageDispatcher.delivered(0x03));
-        assertTrue(MessageDispatcher.written(0x03));
-        assertFalse(MessageDispatcher.written(0x05));
+        assertTrue(MessageDispatcher.expectingWindow(0x03));
+        assertFalse(MessageDispatcher.expectingWindow(0x05));
         assertFalse(MessageDispatcher.delivered(0x05));
         assertTrue(MessageDispatcher.delivered(0x07));
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcherTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/MessageDispatcherTest.java
@@ -25,9 +25,13 @@ public final class MessageDispatcherTest
     @Test
     public void shouldDetectFlagsDelivered()
     {
+        assertFalse(MessageDispatcher.written(0x01));
         assertFalse(MessageDispatcher.delivered(0x01));
+        assertFalse(MessageDispatcher.written(0x02));
         assertFalse(MessageDispatcher.delivered(0x02));
-        assertTrue(MessageDispatcher.delivered(0x03));
+        assertFalse(MessageDispatcher.delivered(0x03));
+        assertTrue(MessageDispatcher.written(0x03));
+        assertFalse(MessageDispatcher.written(0x05));
         assertFalse(MessageDispatcher.delivered(0x05));
         assertTrue(MessageDispatcher.delivered(0x07));
     }


### PR DESCRIPTION
A new dispatch flag is introduced to tell us if any clients are expecting to receive a window frame.  We only stop dispatching if that flag is set true in at least once of the dispatch calls.  That guarantees we will receive a window frame in order to continue dispatching.