### PR TITLE
Fix header matching

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeadersFW.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/HeadersFW.java
@@ -101,14 +101,14 @@ public final class HeadersFW
         // Find first non-matching header condition. If not found, all headerConditions are fulfilled.
         return headerConditions == null ||
                headerConditions.isEmpty() ||
-               null != headerConditions.matchFirst(
+               null == headerConditions.matchFirst(
             h ->
             {
                 boolean[] matchFound = new boolean[]{false};
                 headerSupplier().apply(BufferUtil.wrap(key,  h.key())).forEachRemaining(
                     v -> matchFound[0] = matchFound[0] ||
                              BufferUtil.wrap(value1, v).equals(BufferUtil.wrap(value2, h.value())));
-                return matchFound[0];
+                return !matchFound[0];
             }
         );
     }

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/HeadersFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/HeadersFWTest.java
@@ -142,6 +142,34 @@ public final class HeadersFWTest
     }
 
     @Test
+    public void shouldNotMatchMultipleHeaderConditionsWithOneNotMatched()
+    {
+        headersRO.wrap(rawHeaders,  offset, position);
+        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[100]);
+        ListFW<KafkaHeaderFW> headerConditions =
+            new ListFW.Builder<KafkaHeaderFW.Builder, KafkaHeaderFW>(new KafkaHeaderFW.Builder(), new KafkaHeaderFW())
+                .wrap(buffer, 0, buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value2")))
+                .item(b -> b.key("header2").value(asOctets("junk")))
+                .build();
+        assertFalse(headersRO.matches(headerConditions));
+    }
+
+    @Test
+    public void shouldNotMatchMultipleHeaderConditionsWithBothNotMatched()
+    {
+        headersRO.wrap(rawHeaders,  offset, position);
+        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[100]);
+        ListFW<KafkaHeaderFW> headerConditions =
+            new ListFW.Builder<KafkaHeaderFW.Builder, KafkaHeaderFW>(new KafkaHeaderFW.Builder(), new KafkaHeaderFW())
+                .wrap(buffer, 0, buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("junk")))
+                .item(b -> b.key("header2").value(asOctets("junk")))
+                .build();
+        assertFalse(headersRO.matches(headerConditions));
+    }
+
+    @Test
     public void shouldMatchMultipleHeaderConditionsOnMultiplyOccuringHeader()
     {
         headersRO.wrap(rawHeaders,  offset, position);
@@ -153,6 +181,20 @@ public final class HeadersFWTest
                 .item(b -> b.key("header1").value(asOctets("value2")))
                 .build();
         assertTrue(headersRO.matches(headerConditions));
+    }
+
+    @Test
+    public void shouldNotMatchMultipleHeaderConditionsOnMultiplyOccuringHeader()
+    {
+        headersRO.wrap(rawHeaders,  offset, position);
+        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[100]);
+        ListFW<KafkaHeaderFW> headerConditions =
+            new ListFW.Builder<KafkaHeaderFW.Builder, KafkaHeaderFW>(new KafkaHeaderFW.Builder(), new KafkaHeaderFW())
+                .wrap(buffer, 0, buffer.capacity())
+                .item(b -> b.key("header1").value(asOctets("value1")))
+                .item(b -> b.key("header1").value(asOctets("junk")))
+                .build();
+        assertFalse(headersRO.matches(headerConditions));
     }
 
     @Test
@@ -169,7 +211,7 @@ public final class HeadersFWTest
     }
 
     @Test
-    public void shouldNotMatchSingleHeaderConditionOnSinglelyOccuringHeader()
+    public void shouldNotMatchSingleHeaderConditionOnSinglyOccuringHeader()
     {
         headersRO.wrap(rawHeaders,  offset, position);
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[100]);


### PR DESCRIPTION
Fixes a bug where messages were being delivered with only one of two required header conditions being matched