### PR TITLE
Allow subscribers not keeping up with live message flow to use the message cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
-  - cd nukleus-kafka.spec
-  - git checkout slow_live_consumer
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-kafka.spec
+  - cd nukleus-kafka.spec
+  - git checkout slow_live_consumer
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk8
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.100</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <nukleus.plugin.version>0.32</nukleus.plugin.version>
     <nukleus.version>0.23</nukleus.version>
 
-    <nukleus.kafka.spec.version>0.99</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <reaktor.version>0.60</reaktor.version>
 
     <kafka.clients.version>1.0.0</kafka.clients.version>

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/CompactedPartitionIndex.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/CompactedPartitionIndex.java
@@ -300,7 +300,12 @@ public class CompactedPartitionIndex implements PartitionIndex
 
     private void compact()
     {
-        compact(0, Long.MAX_VALUE);
+        evictExpiredTombstones(); // mutates compactFrom
+
+        if (compactFrom != Integer.MAX_VALUE)
+        {
+            compact(0, Long.MAX_VALUE);
+        }
         compactFrom = Integer.MAX_VALUE;
     }
 

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/ImmutableTopicCache.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/ImmutableTopicCache.java
@@ -26,6 +26,10 @@ import org.reaktivity.nukleus.kafka.internal.types.OctetsFW;
 /**
  * A source of messages for a topic
  */
+/**
+ * @author chris.barrow
+ *
+ */
 public interface ImmutableTopicCache
 {
     public interface MessageRef
@@ -54,4 +58,18 @@ public interface ImmutableTopicCache
     MessageRef getMessage(
         int partition,
         long offset);
+
+    /**
+     * Reports if the cache contains any messages matching the key and headers starting at the given offsets.
+     * This is on a best effort basis, depending on performance cost.
+     * @param fetchOffsets
+     * @param fetchKey
+     * @param headers
+     * @return true if the cache <i>may</i> contain matching messages
+     *         false if the cache definitively does not contain any matching messages
+     */
+    boolean hasMessages(
+        Long2LongHashMap fetchOffsets,
+        OctetsFW fetchKey,
+        ListFW<KafkaHeaderFW> headers);
 }

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/StreamingTopicCache.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/cache/StreamingTopicCache.java
@@ -90,6 +90,14 @@ public final class StreamingTopicCache implements TopicCache
     }
 
     @Override
+    public void extendNextOffset(
+        int partition,
+        long requestOffset,
+        long lastOffset)
+    {
+    }
+
+    @Override
     public Iterator<MessageRef> getMessages(
         Long2LongHashMap fetchOffsets,
         OctetsFW fetchKey,
@@ -107,19 +115,20 @@ public final class StreamingTopicCache implements TopicCache
     }
 
     @Override
-    public void extendNextOffset(
-        int partition,
-        long requestOffset,
-        long lastOffset)
-    {
-    }
-
-    @Override
     public long getOffset(
         int partition,
         OctetsFW key)
     {
         return NO_OFFSET;
+    }
+
+    @Override
+    public boolean hasMessages(
+        Long2LongHashMap fetchOffsets,
+        OctetsFW fetchKey,
+        ListFW<KafkaHeaderFW> headers)
+    {
+        return false;
     }
 
     @Override

--- a/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/BudgetManager.java
+++ b/src/main/java/org/reaktivity/nukleus/kafka/internal/stream/BudgetManager.java
@@ -242,6 +242,12 @@ public class BudgetManager
         {
             return false;
         }
+
+        @Override
+        public String toString()
+        {
+            return Integer.toString(budget);
+        }
     }
 
     BudgetManager()

--- a/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchLimitsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/kafka/internal/stream/CachingFetchLimitsIT.java
@@ -58,8 +58,19 @@ public class CachingFetchLimitsIT
     @Test
     @Specification({
         "${route}/client/controller",
+        "${client}/compacted.messages.slow.consumer/client",
+        "${server}/compacted.messages.slow.consumer/server"})
+    @ScriptProperty("networkAccept \"nukleus://target/streams/kafka\"")
+    public void shouldDeliverCompactedMessagesFromCacheWhenLiveConsumerFallsBehind() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/client/controller",
         "${client}/compacted.historical.large.message.subscribed.to.key/client",
-        "${server}/compacted.messages.large.and.small.repeated/server"})
+        "${server}/compacted.messages.large.and.small/server"})
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
         "applicationConnectWindow \"200\""
@@ -73,7 +84,7 @@ public class CachingFetchLimitsIT
     @Specification({
         "${route}/client/controller",
         "${client}/compacted.historical.large.message.subscribed.to.key/client",
-        "${server}/compacted.messages.large.and.small.repeated/server"})
+        "${server}/compacted.messages.large.and.small/server"})
     @ScriptProperty({
         "networkAccept \"nukleus://target/streams/kafka\"",
         "applicationConnectWindow \"200\""


### PR DESCRIPTION
 Requires https://github.com/reaktivity/nukleus-kafka.spec/pull/85

ClientAcceptStream is altered to allow dispatchState to switch back-and-forth between dispatching messages from the cache and dispatching messages from the connection pool (i.e. Kafka).  Specifically, in the flush method, if not all messages could be dispatched due to lack of window the dispatchState is reverted to dispatching from the cache.